### PR TITLE
Fixed bug with parser

### DIFF
--- a/sample_output/conditions.json
+++ b/sample_output/conditions.json
@@ -25109,7 +25109,7 @@
     },
     "diaper-rash": {
         "condition_name": "Diaper rash",
-        "condition_slug": "diaper-rash-2",
+        "condition_slug": "diaper-rash",
         "condition_description": "Irritant diaper dermatitis, also known as \"diaper dermatitis\" and \"napkin dermatitis\":80 and commonly known as diaper rash (U.S.) or nappy rash (UK, AUS), is a generic term applied to skin rashes in the diaper area that are caused by various skin disorders and/or irritants.",
         "condition_remarks": "Within all the people who go to their doctor with diaper rash, 81% report having diaper rash, 64% report having skin rash, and 56% report having diarrhea. The symptoms that are highly suggestive of diaper rash are diaper rash and irritable infant, although you may still have diaper rash without those symptoms.",
         "symptoms": {
@@ -25162,7 +25162,7 @@
                 "probability": 6
             }
         },
-         "age": {
+        "age": {
             "age-1-years": {
                 "name": "< 1 years",
                 "slug": "age-1-years",
@@ -25954,9 +25954,58 @@
     "zenker-diverticulum": {
         "condition_name": "Zenker diverticulum",
         "condition_slug": "zenker-diverticulum",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "In anatomy, Zenker's diverticulum, also pharyngoesophageal diverticulum, also pharyngeal pouch, also hypopharyngeal diverticulum, is a diverticulum of the mucosa of the pharynx, just above the cricopharyngeal muscle (i.e. above the upper sphincter of the esophagus). It is a false diverticulum (not involving all layers of the esophageal wall).",
+        "condition_remarks": "Within all the people who go to their doctor with zenker diverticulum, 65% report having difficulty in swallowing, 65% report having sharp chest pain, and 47% report having regurgitation. The symptoms that are highly suggestive of zenker diverticulum are difficulty in swallowing, regurgitation, constipation, elbow weakness, low back weakness, wrist weakness, feeling hot and cold, and nailbiting, although you may still have zenker diverticulum without those symptoms.",
+        "symptoms": {
+            "difficulty-in-swallowing": {
+                "slug": "difficulty-in-swallowing",
+                "probability": 65
+            },
+            "sharp-chest-pain": {
+                "slug": "sharp-chest-pain",
+                "probability": 65
+            },
+            "regurgitation": {
+                "slug": "regurgitation",
+                "probability": 47
+            },
+            "low-back-pain": {
+                "slug": "low-back-pain",
+                "probability": 47
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 47
+            },
+            "sore-throat": {
+                "slug": "sore-throat",
+                "probability": 47
+            },
+            "constipation": {
+                "slug": "constipation",
+                "probability": 47
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 4
+            },
+            "low-back-weakness": {
+                "slug": "low-back-weakness",
+                "probability": 4
+            },
+            "wrist-weakness": {
+                "slug": "wrist-weakness",
+                "probability": 4
+            },
+            "feeling-hot-and-cold": {
+                "slug": "feeling-hot-and-cold",
+                "probability": 4
+            },
+            "nailbiting": {
+                "slug": "nailbiting",
+                "probability": 4
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -26037,9 +26086,58 @@
     "strep-throat": {
         "condition_name": "Strep throat",
         "condition_slug": "strep-throat",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Streptococcal pharyngitis, streptococcal tonsillitis, or streptococcal sore throat (known colloquially as strep throat) is a type of pharyngitis caused by a group A streptococcal infection. It affects the pharynx including the tonsils and possibly the larynx. Common symptoms include fever, sore throat, and enlarged lymph nodes. It is the cause of 37% of sore throats among children and 5-15% in adults.",
+        "condition_remarks": "Within all the people who go to their doctor with strep throat, 95% report having sore throat, 85% report having fever, and 59% report having cough. The symptoms that are highly suggestive of strep throat are sore throat, although you may still have strep throat without those symptoms.",
+        "symptoms": {
+            "sore-throat": {
+                "slug": "sore-throat",
+                "probability": 95
+            },
+            "fever": {
+                "slug": "fever",
+                "probability": 85
+            },
+            "cough": {
+                "slug": "cough",
+                "probability": 59
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 50
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 40
+            },
+            "ear-pain": {
+                "slug": "ear-pain",
+                "probability": 39
+            },
+            "nasal-congestion": {
+                "slug": "nasal-congestion",
+                "probability": 38
+            },
+            "skin-rash": {
+                "slug": "skin-rash",
+                "probability": 32
+            },
+            "ache-all-over": {
+                "slug": "ache-all-over",
+                "probability": 28
+            },
+            "difficulty-in-swallowing": {
+                "slug": "difficulty-in-swallowing",
+                "probability": 18
+            },
+            "chills": {
+                "slug": "chills",
+                "probability": 15
+            },
+            "decreased-appetite": {
+                "slug": "decreased-appetite",
+                "probability": 13
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -26120,9 +26218,58 @@
     "stress-incontinence": {
         "condition_name": "Stress incontinence",
         "condition_slug": "stress-incontinence",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Stress incontinence is a form of urinary incontinence.",
+        "condition_remarks": "Within all the people who go to their doctor with stress incontinence, 90% report having involuntary urination, 42% report having frequent urination, and 23% report having symptoms of bladder. The symptoms that are highly suggestive of stress incontinence are involuntary urination, frequent urination, symptoms of bladder, hot flashes, and excessive urination at night, although you may still have stress incontinence without those symptoms.",
+        "symptoms": {
+            "involuntary-urination": {
+                "slug": "involuntary-urination",
+                "probability": 90
+            },
+            "frequent-urination": {
+                "slug": "frequent-urination",
+                "probability": 42
+            },
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 23
+            },
+            "symptoms-of-bladder": {
+                "slug": "symptoms-of-bladder",
+                "probability": 23
+            },
+            "blood-in-urine": {
+                "slug": "blood-in-urine",
+                "probability": 18
+            },
+            "retention-of-urine": {
+                "slug": "retention-of-urine",
+                "probability": 15
+            },
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 15
+            },
+            "hot-flashes": {
+                "slug": "hot-flashes",
+                "probability": 12
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 12
+            },
+            "excessive-urination-at-night": {
+                "slug": "excessive-urination-at-night",
+                "probability": 12
+            },
+            "weight-gain": {
+                "slug": "weight-gain",
+                "probability": 8
+            },
+            "intermenstrual-bleeding": {
+                "slug": "intermenstrual-bleeding",
+                "probability": 8
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -26203,9 +26350,58 @@
     "stricture-of-the-esophagus": {
         "condition_name": "Stricture of the esophagus",
         "condition_slug": "stricture-of-the-esophagus",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A benign esophageal stricture is a narrowing or tightening of the esophagus that causes swallowing difficulties.",
+        "condition_remarks": "Within all the people who go to their doctor with stricture of the esophagus, 82% report having difficulty in swallowing, 53% report having vomiting, and 32% report having regurgitation. The symptoms that are highly suggestive of stricture of the esophagus are difficulty in swallowing, regurgitation, lump in throat, difficulty eating, heartburn, stomach bloating, and recent weight loss, although you may still have stricture of the esophagus without those symptoms.",
+        "symptoms": {
+            "difficulty-in-swallowing": {
+                "slug": "difficulty-in-swallowing",
+                "probability": 82
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 53
+            },
+            "regurgitation": {
+                "slug": "regurgitation",
+                "probability": 32
+            },
+            "lump-in-throat": {
+                "slug": "lump-in-throat",
+                "probability": 26
+            },
+            "sharp-chest-pain": {
+                "slug": "sharp-chest-pain",
+                "probability": 26
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 26
+            },
+            "difficulty-eating": {
+                "slug": "difficulty-eating",
+                "probability": 19
+            },
+            "heartburn": {
+                "slug": "heartburn",
+                "probability": 19
+            },
+            "coughing-up-sputum": {
+                "slug": "coughing-up-sputum",
+                "probability": 19
+            },
+            "stomach-bloating": {
+                "slug": "stomach-bloating",
+                "probability": 19
+            },
+            "problems-with-movement": {
+                "slug": "problems-with-movement",
+                "probability": 11
+            },
+            "recent-weight-loss": {
+                "slug": "recent-weight-loss",
+                "probability": 11
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -26286,9 +26482,58 @@
     "stroke": {
         "condition_name": "Stroke",
         "condition_slug": "stroke",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A stroke, or cerebrovascular accident (CVA), is the rapid loss of brain function due to disturbance in the blood supply to the brain. This can be due to ischemia (lack of blood flow) caused by blockage (thrombosis, arterial embolism), or a hemorrhage. As a result, the affected area of the brain cannot function, which might result in an inability to move one or more limbs on one side of the body, inability to understand or formulate speech, or an inability to see one side of the visual field.",
+        "condition_remarks": "Within all the people who go to their doctor with stroke, 46% report having focal weakness, 43% report having dizziness, and 37% report having headache. The symptoms that are highly suggestive of stroke are focal weakness, problems with movement, slurring words, and difficulty speaking, although you may still have stroke without those symptoms.",
+        "symptoms": {
+            "focal-weakness": {
+                "slug": "focal-weakness",
+                "probability": 46
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 43
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 37
+            },
+            "loss-of-sensation": {
+                "slug": "loss-of-sensation",
+                "probability": 37
+            },
+            "weakness": {
+                "slug": "weakness",
+                "probability": 33
+            },
+            "problems-with-movement": {
+                "slug": "problems-with-movement",
+                "probability": 33
+            },
+            "slurring-words": {
+                "slug": "slurring-words",
+                "probability": 30
+            },
+            "difficulty-speaking": {
+                "slug": "difficulty-speaking",
+                "probability": 29
+            },
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 27
+            },
+            "seizures": {
+                "slug": "seizures",
+                "probability": 23
+            },
+            "abnormal-involuntary-movements": {
+                "slug": "abnormal-involuntary-movements",
+                "probability": 14
+            },
+            "disturbance-of-memory": {
+                "slug": "disturbance-of-memory",
+                "probability": 13
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -26369,9 +26614,58 @@
     "stye": {
         "condition_name": "Stye",
         "condition_slug": "stye",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "An external stye or sty /\u02c8sta\u026a/, also hordeolum /h\u0254r\u02c8di\u02d0\u0259l\u0259m/, is an infection of the sebaceous glands of Zeis at the base of the eyelashes, or an infection of the apocrine sweat glands of Moll. External styes form on the outside of the lids and can be seen as small red bumps. Internal styes are infections of the meibomian sebaceous glands lining the inside of the eyelids. They also cause a red bump underneath the lid with only generalized redness and swelling visible on the outside. Styes are similar to chalazia, but tend to be of smaller size and are more painful and usually produce no lasting damage. They contain water and pus and the bacteria will spread if the stye is forcefully ruptured. Styes are characterized by an acute onset and usually short in duration (7\u201310 days without treatment) compared to chalazia that are chronic and usually do not resolve without intervention. Styes are usually caused by staphylococcus aureus bacterium.",
+        "condition_remarks": "Within all the people who go to their doctor with stye, 74% report having pain in eye, 73% report having swollen eye, and 60% report having eye redness. The symptoms that are highly suggestive of stye are pain in eye, swollen eye, eye redness, eyelid swelling, symptoms of eye, mass on eyelid, itchiness of eye, eyelid lesion or rash, and eye burns or stings, although you may still have stye without those symptoms.",
+        "symptoms": {
+            "pain-in-eye": {
+                "slug": "pain-in-eye",
+                "probability": 74
+            },
+            "swollen-eye": {
+                "slug": "swollen-eye",
+                "probability": 73
+            },
+            "eye-redness": {
+                "slug": "eye-redness",
+                "probability": 60
+            },
+            "eyelid-swelling": {
+                "slug": "eyelid-swelling",
+                "probability": 56
+            },
+            "symptoms-of-eye": {
+                "slug": "symptoms-of-eye",
+                "probability": 46
+            },
+            "mass-on-eyelid": {
+                "slug": "mass-on-eyelid",
+                "probability": 35
+            },
+            "itchiness-of-eye": {
+                "slug": "itchiness-of-eye",
+                "probability": 27
+            },
+            "eyelid-lesion-or-rash": {
+                "slug": "eyelid-lesion-or-rash",
+                "probability": 25
+            },
+            "abnormal-appearing-skin": {
+                "slug": "abnormal-appearing-skin",
+                "probability": 19
+            },
+            "eye-burns-or-stings": {
+                "slug": "eye-burns-or-stings",
+                "probability": 12
+            },
+            "skin-swelling": {
+                "slug": "skin-swelling",
+                "probability": 9
+            },
+            "lacrimation": {
+                "slug": "lacrimation",
+                "probability": 9
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -26452,9 +26746,54 @@
     "subacute-thyroiditis": {
         "condition_name": "Subacute thyroiditis",
         "condition_slug": "subacute-thyroiditis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Subacute thyroiditis is an intriguing form of thyroiditis that can be a cause of both thyrotoxicosis and hypothyroidism. It is uncommon and can affect individuals of both sexes and all ages. The most common form, subacute granulomatous, or de Quervain's, thyroiditis manifests as a sudden and painful enlargement of the thyroid gland accompanied with fever, malaise and muscle aches. Some have suggested that its cause might be viral in origin.",
+        "condition_remarks": "Within all the people who go to their doctor with subacute thyroiditis, 40% report having problems during pregnancy, 29% report having pain during pregnancy, and 24% report having uterine contractions. The symptoms that are highly suggestive of subacute thyroiditis are problems during pregnancy and uterine contractions, although you may still have subacute thyroiditis without those symptoms.",
+        "symptoms": {
+            "problems-during-pregnancy": {
+                "slug": "problems-during-pregnancy",
+                "probability": 40
+            },
+            "pain-during-pregnancy": {
+                "slug": "pain-during-pregnancy",
+                "probability": 29
+            },
+            "uterine-contractions": {
+                "slug": "uterine-contractions",
+                "probability": 24
+            },
+            "sweating": {
+                "slug": "sweating",
+                "probability": 14
+            },
+            "palpitations": {
+                "slug": "palpitations",
+                "probability": 14
+            },
+            "heartburn": {
+                "slug": "heartburn",
+                "probability": 8
+            },
+            "blood-in-stool": {
+                "slug": "blood-in-stool",
+                "probability": 8
+            },
+            "fluid-retention": {
+                "slug": "fluid-retention",
+                "probability": 8
+            },
+            "spotting-or-bleeding-during-pregnancy": {
+                "slug": "spotting-or-bleeding-during-pregnancy",
+                "probability": 8
+            },
+            "pain-of-the-anus": {
+                "slug": "pain-of-the-anus",
+                "probability": 8
+            },
+            "leg-cramps-or-spasms": {
+                "slug": "leg-cramps-or-spasms",
+                "probability": 8
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -26535,9 +26874,58 @@
     "subarachnoid-hemorrhage": {
         "condition_name": "Subarachnoid hemorrhage",
         "condition_slug": "subarachnoid-hemorrhage",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A subarachnoid hemorrhage (SAH, /\u02ccs\u028cb\u0259\u02c8r\u00e6kn\u0254\u026ad \u02c8h\u025bm\u1d4ar\u026ad\u0292/), or subarachnoid haemorrhage in British English, is bleeding into the subarachnoid space\u2014the area between the arachnoid membrane and the pia mater surrounding the brain. This may occur spontaneously, usually from a ruptured cerebral aneurysm, or may result from head injury.",
+        "condition_remarks": "Within all the people who go to their doctor with subarachnoid hemorrhage, 71% report having headache, 35% report having dizziness, and 31% report having neck pain. The symptoms that are highly suggestive of subarachnoid hemorrhage are bleeding from ear, although you may still have subarachnoid hemorrhage without those symptoms.",
+        "symptoms": {
+            "headache": {
+                "slug": "headache",
+                "probability": 71
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 35
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 31
+            },
+            "neck-pain": {
+                "slug": "neck-pain",
+                "probability": 31
+            },
+            "weakness": {
+                "slug": "weakness",
+                "probability": 27
+            },
+            "fainting": {
+                "slug": "fainting",
+                "probability": 27
+            },
+            "loss-of-sensation": {
+                "slug": "loss-of-sensation",
+                "probability": 21
+            },
+            "seizures": {
+                "slug": "seizures",
+                "probability": 21
+            },
+            "symptoms-of-eye": {
+                "slug": "symptoms-of-eye",
+                "probability": 15
+            },
+            "nosebleed": {
+                "slug": "nosebleed",
+                "probability": 15
+            },
+            "bleeding-from-ear": {
+                "slug": "bleeding-from-ear",
+                "probability": 15
+            },
+            "disturbance-of-memory": {
+                "slug": "disturbance-of-memory",
+                "probability": 15
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -26618,9 +27006,58 @@
     "subconjunctival-hemorrhage": {
         "condition_name": "Subconjunctival hemorrhage",
         "condition_slug": "subconjunctival-hemorrhage",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A subconjunctival hemorrhage (or subconjunctival haemorrhage) also known as hyposphagma, is bleeding underneath the conjunctiva. The conjunctiva contains many small, fragile blood vessels that are easily ruptured or broken. When this happens, blood leaks into the space between the conjunctiva and sclera.",
+        "condition_remarks": "Within all the people who go to their doctor with subconjunctival hemorrhage, 70% report having pain in eye, 67% report having eye redness, and 39% report having diminished vision. The symptoms that are highly suggestive of subconjunctival hemorrhage are pain in eye, eye redness, symptoms of eye, swollen eye, bleeding from eye, and eyelid swelling, although you may still have subconjunctival hemorrhage without those symptoms.",
+        "symptoms": {
+            "pain-in-eye": {
+                "slug": "pain-in-eye",
+                "probability": 70
+            },
+            "eye-redness": {
+                "slug": "eye-redness",
+                "probability": 67
+            },
+            "diminished-vision": {
+                "slug": "diminished-vision",
+                "probability": 39
+            },
+            "symptoms-of-eye": {
+                "slug": "symptoms-of-eye",
+                "probability": 36
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 35
+            },
+            "swollen-eye": {
+                "slug": "swollen-eye",
+                "probability": 35
+            },
+            "bleeding-from-eye": {
+                "slug": "bleeding-from-eye",
+                "probability": 32
+            },
+            "facial-pain": {
+                "slug": "facial-pain",
+                "probability": 11
+            },
+            "eyelid-swelling": {
+                "slug": "eyelid-swelling",
+                "probability": 6
+            },
+            "blindness": {
+                "slug": "blindness",
+                "probability": 6
+            },
+            "foreign-body-sensation-in-eye": {
+                "slug": "foreign-body-sensation-in-eye",
+                "probability": 6
+            },
+            "eye-burns-or-stings": {
+                "slug": "eye-burns-or-stings",
+                "probability": 6
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -26701,9 +27138,58 @@
     "subdural-hemorrhage": {
         "condition_name": "Subdural hemorrhage",
         "condition_slug": "subdural-hemorrhage",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A subdural hematoma (American spelling) or subdural haematoma (British spelling), also known as a subdural haemorrhage (SDH), is a type of hematoma, usually associated with traumatic brain injury. Blood gathers within the outermost meningeal layer, between the dura mater, which adheres to the skull, and the arachnoid mater, which envelops the brain. Usually resulting from tears in bridging veins which cross the subdural space, subdural hemorrhages may cause an increase in intracranial pressure (ICP), which can cause compression of and damage to delicate brain tissue. Subdural hematomas are often life-threatening when acute. Chronic subdural hematomas, however, have better prognosis if properly managed.",
+        "condition_remarks": "Within all the people who go to their doctor with subdural hemorrhage, 67% report having headache, 36% report having problems with movement, and 36% report having dizziness. The symptoms that are highly suggestive of subdural hemorrhage are problems with movement and abnormal movement of eyelid, although you may still have subdural hemorrhage without those symptoms.",
+        "symptoms": {
+            "headache": {
+                "slug": "headache",
+                "probability": 67
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 36
+            },
+            "problems-with-movement": {
+                "slug": "problems-with-movement",
+                "probability": 36
+            },
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 28
+            },
+            "seizures": {
+                "slug": "seizures",
+                "probability": 24
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 24
+            },
+            "facial-pain": {
+                "slug": "facial-pain",
+                "probability": 14
+            },
+            "disturbance-of-memory": {
+                "slug": "disturbance-of-memory",
+                "probability": 14
+            },
+            "irritable-infant": {
+                "slug": "irritable-infant",
+                "probability": 7
+            },
+            "abnormal-movement-of-eyelid": {
+                "slug": "abnormal-movement-of-eyelid",
+                "probability": 7
+            },
+            "hostile-behavior": {
+                "slug": "hostile-behavior",
+                "probability": 7
+            },
+            "delusions-or-hallucinations": {
+                "slug": "delusions-or-hallucinations",
+                "probability": 7
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -26784,9 +27270,58 @@
     "substance-related-mental-disorder": {
         "condition_name": "Substance-related mental disorder",
         "condition_slug": "substance-related-mental-disorder",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Substance-related mental disorder is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with substance-related mental disorder, 83% report having depressive or psychotic symptoms, 58% report having delusions or hallucinations, and 52% report having anxiety and nervousness. The symptoms that are highly suggestive of substance-related mental disorder are depressive or psychotic symptoms, delusions or hallucinations, drug abuse, excessive anger, and fears and phobias, although you may still have substance-related mental disorder without those symptoms.",
+        "symptoms": {
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 83
+            },
+            "delusions-or-hallucinations": {
+                "slug": "delusions-or-hallucinations",
+                "probability": 58
+            },
+            "depression": {
+                "slug": "depression",
+                "probability": 52
+            },
+            "anxiety-and-nervousness": {
+                "slug": "anxiety-and-nervousness",
+                "probability": 52
+            },
+            "drug-abuse": {
+                "slug": "drug-abuse",
+                "probability": 46
+            },
+            "abusing-alcohol": {
+                "slug": "abusing-alcohol",
+                "probability": 23
+            },
+            "insomnia": {
+                "slug": "insomnia",
+                "probability": 23
+            },
+            "feeling-ill": {
+                "slug": "feeling-ill",
+                "probability": 18
+            },
+            "excessive-anger": {
+                "slug": "excessive-anger",
+                "probability": 13
+            },
+            "problems-with-movement": {
+                "slug": "problems-with-movement",
+                "probability": 13
+            },
+            "hostile-behavior": {
+                "slug": "hostile-behavior",
+                "probability": 13
+            },
+            "fears-and-phobias": {
+                "slug": "fears-and-phobias",
+                "probability": 13
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -26867,9 +27402,58 @@
     "syndrome-of-inappropriate-secretion-of-adh-siadh": {
         "condition_name": "Syndrome of inappropriate secretion of ADH (SIADH)",
         "condition_slug": "syndrome-of-inappropriate-secretion-of-adh-siadh",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A condition of HYPONATREMIA and renal salt loss attributed to overexpansion of BODY FLUIDS resulting from sustained release of ANTIDIURETIC HORMONES which stimulates renal resorption of water. It is characterized by normal KIDNEY function, high urine OSMOLALITY, low serum osmolality, and neurological dysfunction. Etiologies include ADH-producing neoplasms, injuries or diseases involving the HYPOTHALAMUS, the PITUITARY GLAND, and the LUNG. This syndrome can also be drug-induced.",
+        "condition_remarks": "Within all the people who go to their doctor with syndrome of inappropriate secretion of adh (siadh), 77% report having dizziness, 60% report having feeling ill, and 60% report having weakness. The symptoms that are highly suggestive of syndrome of inappropriate secretion of adh (siadh) are dizziness, weakness, feeling ill, shoulder swelling, vulvar sore, eye strain, and cross-eyed, although you may still have syndrome of inappropriate secretion of adh (siadh) without those symptoms.",
+        "symptoms": {
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 77
+            },
+            "shoulder-pain": {
+                "slug": "shoulder-pain",
+                "probability": 60
+            },
+            "neck-pain": {
+                "slug": "neck-pain",
+                "probability": 60
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 60
+            },
+            "fever": {
+                "slug": "fever",
+                "probability": 60
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 60
+            },
+            "weakness": {
+                "slug": "weakness",
+                "probability": 60
+            },
+            "feeling-ill": {
+                "slug": "feeling-ill",
+                "probability": 60
+            },
+            "shoulder-swelling": {
+                "slug": "shoulder-swelling",
+                "probability": 6
+            },
+            "vulvar-sore": {
+                "slug": "vulvar-sore",
+                "probability": 6
+            },
+            "eye-strain": {
+                "slug": "eye-strain",
+                "probability": 6
+            },
+            "cross-eyed": {
+                "slug": "cross-eyed",
+                "probability": 6
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -26950,9 +27534,58 @@
     "syphilis": {
         "condition_name": "Syphilis",
         "condition_slug": "syphilis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Syphilis is a sexually transmitted infection caused by the spirochete bacterium Treponema pallidum subspecies pallidum. The primary route of transmission is through sexual contact; it may also be transmitted from mother to fetus during pregnancy or at birth, resulting in congenital syphilis. Other human diseases caused by related Treponema pallidum include yaws (subspecies pertenue), pinta (subspecies carateum), and bejel (subspecies endemicum).",
+        "condition_remarks": "Within all the people who go to their doctor with syphilis, 50% report having skin rash, 34% report having headache, and 17% report having foot or toe swelling. The symptoms that are highly suggestive of syphilis are arm lump or mass and muscle weakness, although you may still have syphilis without those symptoms.",
+        "symptoms": {
+            "skin-rash": {
+                "slug": "skin-rash",
+                "probability": 50
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 34
+            },
+            "vaginal-discharge": {
+                "slug": "vaginal-discharge",
+                "probability": 17
+            },
+            "foot-or-toe-swelling": {
+                "slug": "foot-or-toe-swelling",
+                "probability": 17
+            },
+            "itching-of-skin": {
+                "slug": "itching-of-skin",
+                "probability": 17
+            },
+            "arm-lump-or-mass": {
+                "slug": "arm-lump-or-mass",
+                "probability": 9
+            },
+            "problems-during-pregnancy": {
+                "slug": "problems-during-pregnancy",
+                "probability": 9
+            },
+            "muscle-pain": {
+                "slug": "muscle-pain",
+                "probability": 9
+            },
+            "congestion-in-chest": {
+                "slug": "congestion-in-chest",
+                "probability": 9
+            },
+            "disturbance-of-memory": {
+                "slug": "disturbance-of-memory",
+                "probability": 9
+            },
+            "muscle-weakness": {
+                "slug": "muscle-weakness",
+                "probability": 9
+            },
+            "increased-heart-rate": {
+                "slug": "increased-heart-rate",
+                "probability": 9
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -27033,9 +27666,58 @@
     "syringomyelia": {
         "condition_name": "Syringomyelia",
         "condition_slug": "syringomyelia",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Syringomyelia /s\u026a\u02ccr\u026a\u014b\u0261\u0275ma\u026a\u02c8i\u02d0li\u0259/ is a generic term referring to a disorder in which a cyst or cavity forms within the spinal cord. This cyst, called a syrinx, can expand and elongate over time, destroying the spinal cord. The damage may result in pain, paralysis, weakness, and stiffness in the back, shoulders, and extremities. Syringomyelia may also cause a loss of the ability to feel extremes of hot or cold, especially in the hands. The disorder generally leads to a cape-like loss of pain and temperature sensation along the back and arms. Each patient experiences a different combination of symptoms. These symptoms typically vary depending on the extent and, often more critically, to the location of the syrinx within the spinal cord.",
+        "condition_remarks": "Within all the people who go to their doctor with syringomyelia, 81% report having back pain, 64% report having shoulder pain, and 53% report having neck pain. The symptoms that are highly suggestive of syringomyelia are leg weakness, hand or finger swelling, pain or soreness of breast, shoulder swelling, and arm stiffness or tightness, although you may still have syringomyelia without those symptoms.",
+        "symptoms": {
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 81
+            },
+            "shoulder-pain": {
+                "slug": "shoulder-pain",
+                "probability": 64
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 53
+            },
+            "neck-pain": {
+                "slug": "neck-pain",
+                "probability": 53
+            },
+            "side-pain": {
+                "slug": "side-pain",
+                "probability": 36
+            },
+            "leg-weakness": {
+                "slug": "leg-weakness",
+                "probability": 36
+            },
+            "hand-or-finger-swelling": {
+                "slug": "hand-or-finger-swelling",
+                "probability": 36
+            },
+            "fainting": {
+                "slug": "fainting",
+                "probability": 36
+            },
+            "pain-or-soreness-of-breast": {
+                "slug": "pain-or-soreness-of-breast",
+                "probability": 36
+            },
+            "foot-or-toe-pain": {
+                "slug": "foot-or-toe-pain",
+                "probability": 36
+            },
+            "shoulder-swelling": {
+                "slug": "shoulder-swelling",
+                "probability": 36
+            },
+            "arm-stiffness-or-tightness": {
+                "slug": "arm-stiffness-or-tightness",
+                "probability": 36
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -27116,9 +27798,58 @@
     "systemic-lupus-erythematosis-sle": {
         "condition_name": "Systemic lupus erythematosis (SLE)",
         "condition_slug": "systemic-lupus-erythematosis-sle",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Systemic lupus erythematosus i/s\u026a\u02c8st\u025bm\u026ak \u02c8lu\u02d0p\u0259s \u02cc\u025br\u026a\u03b8i\u02d0m\u0259\u02c8to\u028as\u0259s/, often abbreviated to SLE or lupus, is a systemic autoimmune disease (or autoimmune connective tissue disease) that can affect any part of the body. As occurs in other autoimmune diseases, the immune system attacks the body's cells and tissue, resulting in inflammation and tissue damage. It is a Type III hypersensitivity reaction in which antibody-immune complexes precipitate and cause a further immune response.",
+        "condition_remarks": "Within all the people who go to their doctor with systemic lupus erythematosis (sle), 29% report having sharp chest pain, 26% report having ache all over, and 24% report having joint pain. The symptoms that are highly suggestive of systemic lupus erythematosis (sle) are joint pain and joint swelling, although you may still have systemic lupus erythematosis (sle) without those symptoms.",
+        "symptoms": {
+            "sharp-chest-pain": {
+                "slug": "sharp-chest-pain",
+                "probability": 29
+            },
+            "ache-all-over": {
+                "slug": "ache-all-over",
+                "probability": 26
+            },
+            "joint-pain": {
+                "slug": "joint-pain",
+                "probability": 24
+            },
+            "knee-pain": {
+                "slug": "knee-pain",
+                "probability": 24
+            },
+            "leg-swelling": {
+                "slug": "leg-swelling",
+                "probability": 8
+            },
+            "muscle-pain": {
+                "slug": "muscle-pain",
+                "probability": 8
+            },
+            "joint-swelling": {
+                "slug": "joint-swelling",
+                "probability": 4
+            },
+            "focal-weakness": {
+                "slug": "focal-weakness",
+                "probability": 4
+            },
+            "bones-are-painful": {
+                "slug": "bones-are-painful",
+                "probability": 4
+            },
+            "absence-of-menstruation": {
+                "slug": "absence-of-menstruation",
+                "probability": 2
+            },
+            "too-little-hair": {
+                "slug": "too-little-hair",
+                "probability": 2
+            },
+            "hand-or-finger-stiffness-or-tightness": {
+                "slug": "hand-or-finger-stiffness-or-tightness",
+                "probability": 2
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -27199,9 +27930,58 @@
     "teething-syndrome": {
         "condition_name": "Teething syndrome",
         "condition_slug": "teething-syndrome",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Teething syndrome is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with teething syndrome, 82% report having fever, 65% report having irritable infant, and 65% report having pulling at ears. The symptoms that are highly suggestive of teething syndrome are pulling at ears, irritable infant, gum pain, symptoms of infants, temper problems, and redness in ear, although you may still have teething syndrome without those symptoms.",
+        "symptoms": {
+            "fever": {
+                "slug": "fever",
+                "probability": 82
+            },
+            "pulling-at-ears": {
+                "slug": "pulling-at-ears",
+                "probability": 65
+            },
+            "cough": {
+                "slug": "cough",
+                "probability": 65
+            },
+            "irritable-infant": {
+                "slug": "irritable-infant",
+                "probability": 65
+            },
+            "nasal-congestion": {
+                "slug": "nasal-congestion",
+                "probability": 63
+            },
+            "diarrhea": {
+                "slug": "diarrhea",
+                "probability": 46
+            },
+            "ear-pain": {
+                "slug": "ear-pain",
+                "probability": 40
+            },
+            "gum-pain": {
+                "slug": "gum-pain",
+                "probability": 40
+            },
+            "symptoms-of-infants": {
+                "slug": "symptoms-of-infants",
+                "probability": 38
+            },
+            "temper-problems": {
+                "slug": "temper-problems",
+                "probability": 34
+            },
+            "redness-in-ear": {
+                "slug": "redness-in-ear",
+                "probability": 27
+            },
+            "decreased-appetite": {
+                "slug": "decreased-appetite",
+                "probability": 23
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -27282,9 +28062,58 @@
     "temporary-or-benign-blood-in-urine": {
         "condition_name": "Temporary or benign blood in urine",
         "condition_slug": "temporary-or-benign-blood-in-urine",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Temporary or benign blood in urine is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with temporary or benign blood in urine, 89% report having blood in urine, 40% report having sharp abdominal pain, and 35% report having painful urination. The symptoms that are highly suggestive of temporary or benign blood in urine are blood in urine and symptoms of bladder, although you may still have temporary or benign blood in urine without those symptoms.",
+        "symptoms": {
+            "blood-in-urine": {
+                "slug": "blood-in-urine",
+                "probability": 89
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 40
+            },
+            "side-pain": {
+                "slug": "side-pain",
+                "probability": 35
+            },
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 35
+            },
+            "retention-of-urine": {
+                "slug": "retention-of-urine",
+                "probability": 32
+            },
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 31
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 29
+            },
+            "frequent-urination": {
+                "slug": "frequent-urination",
+                "probability": 25
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 17
+            },
+            "involuntary-urination": {
+                "slug": "involuntary-urination",
+                "probability": 14
+            },
+            "symptoms-of-bladder": {
+                "slug": "symptoms-of-bladder",
+                "probability": 8
+            },
+            "regurgitation": {
+                "slug": "regurgitation",
+                "probability": 6
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -27365,9 +28194,58 @@
     "temporomandibular-joint-disorder": {
         "condition_name": "Temporomandibular joint disorder",
         "condition_slug": "temporomandibular-joint-disorder",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Temporomandibular joint dysfunction (sometimes abbreviated to TMD and also termed temporomandibular joint dysfunction syndrome, temporomandibular disorder or many other names), is an umbrella term covering pain and dysfunction of the muscles of mastication (the muscles that move the jaw) and the temporomandibular joints (the joints which connect the mandible to the skull). The most important feature is pain, followed by restricted mandibular movement, which can cause difficulty eating or speaking, and noises from the temporomandibular joints (TMJ) during jaw movement. Although TMD is not life threatening, it can detriment quality of life, because the symptoms can become chronic and difficult to manage. TMD is thought to be very common. About 20-30% of the adult population are affected to some degree. Usually people affected by TMD are between 20 and 40 years of age, and it is more common in females than males. TMD is the second most frequent cause of orofacial pain after dental pain (e.g. toothache).",
+        "condition_remarks": "Within all the people who go to their doctor with temporomandibular joint disorder, 84% report having facial pain, 81% report having ear pain, and 54% report having headache. The symptoms that are highly suggestive of temporomandibular joint disorder are facial pain, ear pain, ringing in ear, and jaw pain, although you may still have temporomandibular joint disorder without those symptoms.",
+        "symptoms": {
+            "facial-pain": {
+                "slug": "facial-pain",
+                "probability": 84
+            },
+            "ear-pain": {
+                "slug": "ear-pain",
+                "probability": 81
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 54
+            },
+            "neck-pain": {
+                "slug": "neck-pain",
+                "probability": 46
+            },
+            "nasal-congestion": {
+                "slug": "nasal-congestion",
+                "probability": 29
+            },
+            "sore-throat": {
+                "slug": "sore-throat",
+                "probability": 27
+            },
+            "toothache": {
+                "slug": "toothache",
+                "probability": 27
+            },
+            "ringing-in-ear": {
+                "slug": "ringing-in-ear",
+                "probability": 24
+            },
+            "diminished-hearing": {
+                "slug": "diminished-hearing",
+                "probability": 24
+            },
+            "pain-in-eye": {
+                "slug": "pain-in-eye",
+                "probability": 18
+            },
+            "jaw-pain": {
+                "slug": "jaw-pain",
+                "probability": 18
+            },
+            "redness-in-ear": {
+                "slug": "redness-in-ear",
+                "probability": 18
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -27448,9 +28326,58 @@
     "tendinitis": {
         "condition_name": "Tendinitis",
         "condition_slug": "tendinitis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Tendinitis (informally also tendonitis), meaning inflammation of a tendon, is a type of tendinopathy often confused with the more common tendinosis, which has similar symptoms but requires different treatment. (The suffix -itis denotes diseases characterized by inflammation.) The term tendinitis should be reserved for tendon injuries that involve larger-scale acute injuries accompanied by inflammation. Generally tendinitis is referred to by the body part involved, such as Achilles tendinitis (affecting the Achilles tendon), or patellar tendinitis (jumper's knee, affecting the patellar tendon).",
+        "condition_remarks": "Within all the people who go to their doctor with tendinitis, 61% report having hip pain, 54% report having shoulder pain, and 53% report having knee pain. The symptoms that are highly suggestive of tendinitis are hip pain, wrist pain, and elbow pain, although you may still have tendinitis without those symptoms.",
+        "symptoms": {
+            "hip-pain": {
+                "slug": "hip-pain",
+                "probability": 61
+            },
+            "shoulder-pain": {
+                "slug": "shoulder-pain",
+                "probability": 54
+            },
+            "knee-pain": {
+                "slug": "knee-pain",
+                "probability": 53
+            },
+            "wrist-pain": {
+                "slug": "wrist-pain",
+                "probability": 48
+            },
+            "foot-or-toe-pain": {
+                "slug": "foot-or-toe-pain",
+                "probability": 46
+            },
+            "hand-or-finger-pain": {
+                "slug": "hand-or-finger-pain",
+                "probability": 45
+            },
+            "leg-pain": {
+                "slug": "leg-pain",
+                "probability": 40
+            },
+            "elbow-pain": {
+                "slug": "elbow-pain",
+                "probability": 35
+            },
+            "ankle-pain": {
+                "slug": "ankle-pain",
+                "probability": 35
+            },
+            "arm-pain": {
+                "slug": "arm-pain",
+                "probability": 31
+            },
+            "hand-or-finger-swelling": {
+                "slug": "hand-or-finger-swelling",
+                "probability": 11
+            },
+            "joint-pain": {
+                "slug": "joint-pain",
+                "probability": 11
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -27531,9 +28458,58 @@
     "tension-headache": {
         "condition_name": "Tension headache",
         "condition_slug": "tension-headache",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A tension headache (renamed a tension-type headache by the International Headache Society in 1988) is the most common type of primary headache. The pain can radiate from the lower back of the head, the neck, eyes, or other muscle groups in the body. Tension-type headaches account for nearly 90% of all headaches. Approximately 3% of the population has chronic tension-type headaches.",
+        "condition_remarks": "Within all the people who go to their doctor with tension headache, 97% report having headache, 51% report having neck pain, and 36% report having nausea. The symptoms that are highly suggestive of tension headache are headache, although you may still have tension headache without those symptoms.",
+        "symptoms": {
+            "headache": {
+                "slug": "headache",
+                "probability": 97
+            },
+            "neck-pain": {
+                "slug": "neck-pain",
+                "probability": 51
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 36
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 32
+            },
+            "anxiety-and-nervousness": {
+                "slug": "anxiety-and-nervousness",
+                "probability": 28
+            },
+            "chills": {
+                "slug": "chills",
+                "probability": 11
+            },
+            "neck-stiffness-or-tightness": {
+                "slug": "neck-stiffness-or-tightness",
+                "probability": 5
+            },
+            "painful-menstruation": {
+                "slug": "painful-menstruation",
+                "probability": 5
+            },
+            "painful-sinuses": {
+                "slug": "painful-sinuses",
+                "probability": 5
+            },
+            "symptoms-of-the-face": {
+                "slug": "symptoms-of-the-face",
+                "probability": 5
+            },
+            "bleeding-from-ear": {
+                "slug": "bleeding-from-ear",
+                "probability": 2
+            },
+            "back-cramps-or-spasms": {
+                "slug": "back-cramps-or-spasms",
+                "probability": 2
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -27614,9 +28590,58 @@
     "testicular-cancer": {
         "condition_name": "Testicular cancer",
         "condition_slug": "testicular-cancer",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Testicular cancer is cancer that develops in the testicles, a part of the male reproductive system.",
+        "condition_remarks": "Within all the people who go to their doctor with testicular cancer, 36% report having mass in scrotum, 27% report having ache all over, and 27% report having anxiety and nervousness. The symptoms that are highly suggestive of testicular cancer are mass in scrotum, symptoms of the scrotum and testes, skin on arm or hand looks infected, and pain in testicles, although you may still have testicular cancer without those symptoms.",
+        "symptoms": {
+            "mass-in-scrotum": {
+                "slug": "mass-in-scrotum",
+                "probability": 36
+            },
+            "anxiety-and-nervousness": {
+                "slug": "anxiety-and-nervousness",
+                "probability": 27
+            },
+            "ache-all-over": {
+                "slug": "ache-all-over",
+                "probability": 27
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 27
+            },
+            "groin-pain": {
+                "slug": "groin-pain",
+                "probability": 16
+            },
+            "symptoms-of-the-scrotum-and-testes": {
+                "slug": "symptoms-of-the-scrotum-and-testes",
+                "probability": 16
+            },
+            "skin-on-arm-or-hand-looks-infected": {
+                "slug": "skin-on-arm-or-hand-looks-infected",
+                "probability": 16
+            },
+            "blood-in-urine": {
+                "slug": "blood-in-urine",
+                "probability": 16
+            },
+            "chills": {
+                "slug": "chills",
+                "probability": 16
+            },
+            "diminished-hearing": {
+                "slug": "diminished-hearing",
+                "probability": 16
+            },
+            "pain-in-testicles": {
+                "slug": "pain-in-testicles",
+                "probability": 16
+            },
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 16
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -27697,9 +28722,58 @@
     "testicular-disorder": {
         "condition_name": "Testicular disorder",
         "condition_slug": "testicular-disorder",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "The testicle (from Latin testiculus, diminutive of testis, meaning \"witness\" of virility, plural testes) is the male gonad in animals. Like the ovaries to which they are homologous, testes are components of both the reproductive system and the endocrine system. The primary functions of the testes are to produce sperm (spermatogenesis) and to produce androgens, primarily testosterone.",
+        "condition_remarks": "Within all the people who go to their doctor with testicular disorder, 56% report having impotence, 38% report having fatigue, and 26% report having loss of sex drive. The symptoms that are highly suggestive of testicular disorder are impotence, loss of sex drive, symptoms of prostate, symptoms of the scrotum and testes, excessive urination at night, and mass in scrotum, although you may still have testicular disorder without those symptoms.",
+        "symptoms": {
+            "impotence": {
+                "slug": "impotence",
+                "probability": 56
+            },
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 38
+            },
+            "loss-of-sex-drive": {
+                "slug": "loss-of-sex-drive",
+                "probability": 26
+            },
+            "symptoms-of-prostate": {
+                "slug": "symptoms-of-prostate",
+                "probability": 13
+            },
+            "symptoms-of-the-scrotum-and-testes": {
+                "slug": "symptoms-of-the-scrotum-and-testes",
+                "probability": 13
+            },
+            "pain-in-testicles": {
+                "slug": "pain-in-testicles",
+                "probability": 13
+            },
+            "excessive-urination-at-night": {
+                "slug": "excessive-urination-at-night",
+                "probability": 13
+            },
+            "skin-moles": {
+                "slug": "skin-moles",
+                "probability": 5
+            },
+            "excessive-anger": {
+                "slug": "excessive-anger",
+                "probability": 5
+            },
+            "hoarse-voice": {
+                "slug": "hoarse-voice",
+                "probability": 5
+            },
+            "regurgitation": {
+                "slug": "regurgitation",
+                "probability": 5
+            },
+            "mass-in-scrotum": {
+                "slug": "mass-in-scrotum",
+                "probability": 5
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -27780,9 +28854,58 @@
     "testicular-torsion": {
         "condition_name": "Testicular torsion",
         "condition_slug": "testicular-torsion",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Testicular torsion occurs when the spermatic cord (from which the testicle is suspended) twists, cutting off the testicle's blood supply, a condition called ischemia. The principal symptom is rapid onset of testicular pain. The most common underlying cause is a congenital malformation known as a \"bell-clapper deformity\" wherein the testis is inadequately affixed to the scrotum allowing it to move freely on its axis and susceptible to induced twisting of the cord and its vessels. The diagnosis can be made clinically but an urgent ultrasound is helpful in evaluation. Irreversible ischemia begins around six hours after onset and emergency diagnosis and treatment is required within this time in order to minimize necrosis and to improve the chance of salvaging the testicle.",
+        "condition_remarks": "Within all the people who go to their doctor with testicular torsion, 80% report having pain in testicles, 76% report having symptoms of the scrotum and testes, and 63% report having swelling of scrotum. The symptoms that are highly suggestive of testicular torsion are pain in testicles, symptoms of the scrotum and testes, swelling of scrotum, emotional symptoms, elbow cramps or spasms, nailbiting, itching of scrotum, elbow weakness, and muscle swelling, although you may still have testicular torsion without those symptoms.",
+        "symptoms": {
+            "pain-in-testicles": {
+                "slug": "pain-in-testicles",
+                "probability": 80
+            },
+            "symptoms-of-the-scrotum-and-testes": {
+                "slug": "symptoms-of-the-scrotum-and-testes",
+                "probability": 76
+            },
+            "swelling-of-scrotum": {
+                "slug": "swelling-of-scrotum",
+                "probability": 63
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 52
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 34
+            },
+            "burning-abdominal-pain": {
+                "slug": "burning-abdominal-pain",
+                "probability": 34
+            },
+            "emotional-symptoms": {
+                "slug": "emotional-symptoms",
+                "probability": 2
+            },
+            "elbow-cramps-or-spasms": {
+                "slug": "elbow-cramps-or-spasms",
+                "probability": 2
+            },
+            "nailbiting": {
+                "slug": "nailbiting",
+                "probability": 2
+            },
+            "itching-of-scrotum": {
+                "slug": "itching-of-scrotum",
+                "probability": 2
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 2
+            },
+            "muscle-swelling": {
+                "slug": "muscle-swelling",
+                "probability": 2
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -27863,9 +28986,58 @@
     "thalassemia": {
         "condition_name": "Thalassemia",
         "condition_slug": "thalassemia",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Thalassemia (British English: thalassaemia) are forms of inherited autosomal recessive blood disorders that originated in the Mediterranean region. In thalassemia, the disease is caused by the weakening and destruction of red blood cells. Thalassemia is caused by variant or missing genes that affect how the body makes hemoglobin. Hemoglobin is the protein in red blood cells that carries oxygen. People with thalassemia make less hemoglobin and fewer circulating red blood cells than normal, which results in mild or severe anemia. Thalassemia will present as microcytic anemia which may be differentiated from iron deficiency anemia using the mentzer index calculation.",
+        "condition_remarks": "Within all the people who go to their doctor with thalassemia, 23% report having pain in testicles, 23% report having knee swelling, and 23% report having regurgitation. The symptoms that are highly suggestive of thalassemia are regurgitation, knee swelling, pain in testicles, muscle swelling, low back weakness, and elbow weakness, although you may still have thalassemia without those symptoms.",
+        "symptoms": {
+            "congestion-in-chest": {
+                "slug": "congestion-in-chest",
+                "probability": 23
+            },
+            "insomnia": {
+                "slug": "insomnia",
+                "probability": 23
+            },
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 23
+            },
+            "regurgitation": {
+                "slug": "regurgitation",
+                "probability": 23
+            },
+            "coryza": {
+                "slug": "coryza",
+                "probability": 23
+            },
+            "knee-swelling": {
+                "slug": "knee-swelling",
+                "probability": 23
+            },
+            "diminished-vision": {
+                "slug": "diminished-vision",
+                "probability": 23
+            },
+            "pain-in-testicles": {
+                "slug": "pain-in-testicles",
+                "probability": 23
+            },
+            "arm-pain": {
+                "slug": "arm-pain",
+                "probability": 23
+            },
+            "muscle-swelling": {
+                "slug": "muscle-swelling",
+                "probability": 1
+            },
+            "low-back-weakness": {
+                "slug": "low-back-weakness",
+                "probability": 1
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 1
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -27946,9 +29118,58 @@
     "thoracic-aortic-aneurysm": {
         "condition_name": "Thoracic aortic aneurysm",
         "condition_slug": "thoracic-aortic-aneurysm",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A thoracic aortic aneurysm is an aortic aneurysm that presents primarily in the thorax.",
+        "condition_remarks": "Within all the people who go to their doctor with thoracic aortic aneurysm, 68% report having sharp chest pain, 42% report having dizziness, and 38% report having shortness of breath. The symptoms that are highly suggestive of thoracic aortic aneurysm are unusual color or odor to urine, flushing, leg cramps or spasms, and jaundice, although you may still have thoracic aortic aneurysm without those symptoms.",
+        "symptoms": {
+            "sharp-chest-pain": {
+                "slug": "sharp-chest-pain",
+                "probability": 68
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 42
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 38
+            },
+            "shortness-of-breath": {
+                "slug": "shortness-of-breath",
+                "probability": 38
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 29
+            },
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 23
+            },
+            "chest-tightness": {
+                "slug": "chest-tightness",
+                "probability": 17
+            },
+            "unusual-color-or-odor-to-urine": {
+                "slug": "unusual-color-or-odor-to-urine",
+                "probability": 9
+            },
+            "flushing": {
+                "slug": "flushing",
+                "probability": 9
+            },
+            "leg-cramps-or-spasms": {
+                "slug": "leg-cramps-or-spasms",
+                "probability": 9
+            },
+            "coughing-up-sputum": {
+                "slug": "coughing-up-sputum",
+                "probability": 9
+            },
+            "jaundice": {
+                "slug": "jaundice",
+                "probability": 9
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -28029,9 +29250,58 @@
     "thoracic-outlet-syndrome": {
         "condition_name": "Thoracic outlet syndrome",
         "condition_slug": "thoracic-outlet-syndrome",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Thoracic outlet syndrome (TOS) is a syndrome involving compression at the superior thoracic outlet wherein excess pressure placed on a neurovascular bundle passing between the anterior scalene and middle scalene muscles. It can affect one or more of the nerves that innervate the upper limb and/or blood vessels as they pass between the chest and upper extremity; specifically in the brachial plexus, the subclavian artery, and - rarely - the subclavian vein, which does not normally pass through the scalene hiatus.",
+        "condition_remarks": "Within all the people who go to their doctor with thoracic outlet syndrome, 68% report having arm pain, 68% report having neck pain, and 54% report having shoulder pain. The symptoms that are highly suggestive of thoracic outlet syndrome are arm pain, paresthesia, hand or finger weakness, and shoulder weakness, although you may still have thoracic outlet syndrome without those symptoms.",
+        "symptoms": {
+            "neck-pain": {
+                "slug": "neck-pain",
+                "probability": 68
+            },
+            "arm-pain": {
+                "slug": "arm-pain",
+                "probability": 68
+            },
+            "shoulder-pain": {
+                "slug": "shoulder-pain",
+                "probability": 54
+            },
+            "loss-of-sensation": {
+                "slug": "loss-of-sensation",
+                "probability": 43
+            },
+            "paresthesia": {
+                "slug": "paresthesia",
+                "probability": 43
+            },
+            "sharp-chest-pain": {
+                "slug": "sharp-chest-pain",
+                "probability": 36
+            },
+            "weakness": {
+                "slug": "weakness",
+                "probability": 36
+            },
+            "hand-or-finger-weakness": {
+                "slug": "hand-or-finger-weakness",
+                "probability": 36
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 27
+            },
+            "hand-or-finger-pain": {
+                "slug": "hand-or-finger-pain",
+                "probability": 27
+            },
+            "shoulder-weakness": {
+                "slug": "shoulder-weakness",
+                "probability": 16
+            },
+            "decreased-appetite": {
+                "slug": "decreased-appetite",
+                "probability": 16
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -28112,9 +29382,58 @@
     "threatened-pregnancy": {
         "condition_name": "Threatened pregnancy",
         "condition_slug": "threatened-pregnancy",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Miscarriage is the spontaneous end of a pregnancy at a stage where the embryo or fetus is incapable of surviving independently. Miscarriage is the most common complication of early pregnancy.",
+        "condition_remarks": "Within all the people who go to their doctor with threatened pregnancy, 79% report having spotting or bleeding during pregnancy, 69% report having sharp abdominal pain, and 69% report having pain during pregnancy. The symptoms that are highly suggestive of threatened pregnancy are spotting or bleeding during pregnancy, pain during pregnancy, uterine contractions, problems during pregnancy, cramps and spasms, intermenstrual bleeding, and blood clots during menstrual periods, although you may still have threatened pregnancy without those symptoms.",
+        "symptoms": {
+            "spotting-or-bleeding-during-pregnancy": {
+                "slug": "spotting-or-bleeding-during-pregnancy",
+                "probability": 79
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 69
+            },
+            "pain-during-pregnancy": {
+                "slug": "pain-during-pregnancy",
+                "probability": 69
+            },
+            "uterine-contractions": {
+                "slug": "uterine-contractions",
+                "probability": 67
+            },
+            "problems-during-pregnancy": {
+                "slug": "problems-during-pregnancy",
+                "probability": 38
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 35
+            },
+            "cramps-and-spasms": {
+                "slug": "cramps-and-spasms",
+                "probability": 28
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 24
+            },
+            "intermenstrual-bleeding": {
+                "slug": "intermenstrual-bleeding",
+                "probability": 22
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 18
+            },
+            "blood-clots-during-menstrual-periods": {
+                "slug": "blood-clots-during-menstrual-periods",
+                "probability": 10
+            },
+            "vaginal-discharge": {
+                "slug": "vaginal-discharge",
+                "probability": 8
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -28195,9 +29514,58 @@
     "thrombocytopenia": {
         "condition_name": "Thrombocytopenia",
         "condition_slug": "thrombocytopenia",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "The terms thrombocytopenia and thrombopenia refer to a relative decrease of platelets in blood.",
+        "condition_remarks": "Within all the people who go to their doctor with thrombocytopenia, 26% report having sharp chest pain, 21% report having fatigue, and 13% report having blood in urine. The symptoms that are highly suggestive of thrombocytopenia are bleeding gums, although you may still have thrombocytopenia without those symptoms.",
+        "symptoms": {
+            "sharp-chest-pain": {
+                "slug": "sharp-chest-pain",
+                "probability": 26
+            },
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 21
+            },
+            "blood-in-urine": {
+                "slug": "blood-in-urine",
+                "probability": 13
+            },
+            "nosebleed": {
+                "slug": "nosebleed",
+                "probability": 11
+            },
+            "blood-in-stool": {
+                "slug": "blood-in-stool",
+                "probability": 7
+            },
+            "bleeding-gums": {
+                "slug": "bleeding-gums",
+                "probability": 5
+            },
+            "tongue-lesions": {
+                "slug": "tongue-lesions",
+                "probability": 2
+            },
+            "eyelid-swelling": {
+                "slug": "eyelid-swelling",
+                "probability": 2
+            },
+            "mouth-pain": {
+                "slug": "mouth-pain",
+                "probability": 2
+            },
+            "irregular-belly-button": {
+                "slug": "irregular-belly-button",
+                "probability": 2
+            },
+            "lymphedema": {
+                "slug": "lymphedema",
+                "probability": 2
+            },
+            "irregular-appearing-scalp": {
+                "slug": "irregular-appearing-scalp",
+                "probability": 2
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -28278,9 +29646,58 @@
     "thrombophlebitis": {
         "condition_name": "Thrombophlebitis",
         "condition_slug": "thrombophlebitis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Thrombophlebitis is phlebitis (vein inflammation) related to a thrombus (blood clot). When it occurs repeatedly in different locations, it is known as \"Thrombophlebitis migrans\" or \"migrating thrombophlebitis\".",
+        "condition_remarks": "Within all the people who go to their doctor with thrombophlebitis, 70% report having leg pain, 40% report having leg swelling, and 31% report having arm pain. The symptoms that are highly suggestive of thrombophlebitis are leg swelling, arm swelling, lymphedema, skin on leg or foot looks infected, and leg cramps or spasms, although you may still have thrombophlebitis without those symptoms.",
+        "symptoms": {
+            "leg-pain": {
+                "slug": "leg-pain",
+                "probability": 70
+            },
+            "leg-swelling": {
+                "slug": "leg-swelling",
+                "probability": 40
+            },
+            "arm-pain": {
+                "slug": "arm-pain",
+                "probability": 31
+            },
+            "abnormal-appearing-skin": {
+                "slug": "abnormal-appearing-skin",
+                "probability": 29
+            },
+            "arm-swelling": {
+                "slug": "arm-swelling",
+                "probability": 29
+            },
+            "foot-or-toe-pain": {
+                "slug": "foot-or-toe-pain",
+                "probability": 27
+            },
+            "ache-all-over": {
+                "slug": "ache-all-over",
+                "probability": 24
+            },
+            "lymphedema": {
+                "slug": "lymphedema",
+                "probability": 22
+            },
+            "skin-on-leg-or-foot-looks-infected": {
+                "slug": "skin-on-leg-or-foot-looks-infected",
+                "probability": 14
+            },
+            "skin-swelling": {
+                "slug": "skin-swelling",
+                "probability": 11
+            },
+            "leg-cramps-or-spasms": {
+                "slug": "leg-cramps-or-spasms",
+                "probability": 11
+            },
+            "hand-or-finger-swelling": {
+                "slug": "hand-or-finger-swelling",
+                "probability": 11
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -28361,9 +29778,46 @@
     "thyroid-cancer": {
         "condition_name": "Thyroid cancer",
         "condition_slug": "thyroid-cancer",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Thyroid cancer is a thyroid neoplasm that originates from follicular or parafollicular thyroid cells and is malignant.",
+        "condition_remarks": "Within all the people who go to their doctor with thyroid cancer, 22% report having fatigue, 17% report having difficulty in swallowing, and 12% report having neck mass. The symptoms that are highly suggestive of thyroid cancer are neck mass, stiffness all over, neck swelling, and arm weakness, although you may still have thyroid cancer without those symptoms.",
+        "symptoms": {
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 22
+            },
+            "difficulty-in-swallowing": {
+                "slug": "difficulty-in-swallowing",
+                "probability": 17
+            },
+            "neck-mass": {
+                "slug": "neck-mass",
+                "probability": 12
+            },
+            "leg-weakness": {
+                "slug": "leg-weakness",
+                "probability": 7
+            },
+            "stiffness-all-over": {
+                "slug": "stiffness-all-over",
+                "probability": 7
+            },
+            "neck-swelling": {
+                "slug": "neck-swelling",
+                "probability": 7
+            },
+            "swollen-lymph-nodes": {
+                "slug": "swollen-lymph-nodes",
+                "probability": 7
+            },
+            "arm-weakness": {
+                "slug": "arm-weakness",
+                "probability": 7
+            },
+            "delusions-or-hallucinations": {
+                "slug": "delusions-or-hallucinations",
+                "probability": 7
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -28444,9 +29898,58 @@
     "thyroid-disease": {
         "condition_name": "Thyroid disease",
         "condition_slug": "thyroid-disease",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A thyroid disease is a medical condition impairing the function of the thyroid.",
+        "condition_remarks": "Within all the people who go to their doctor with thyroid disease, 19% report having neck mass, 14% report having difficulty in swallowing, and 6% report having lump in throat. The symptoms that are highly suggestive of thyroid disease are neck mass and lump in throat, although you may still have thyroid disease without those symptoms.",
+        "symptoms": {
+            "neck-mass": {
+                "slug": "neck-mass",
+                "probability": 19
+            },
+            "difficulty-in-swallowing": {
+                "slug": "difficulty-in-swallowing",
+                "probability": 14
+            },
+            "hot-flashes": {
+                "slug": "hot-flashes",
+                "probability": 6
+            },
+            "neck-swelling": {
+                "slug": "neck-swelling",
+                "probability": 6
+            },
+            "hostile-behavior": {
+                "slug": "hostile-behavior",
+                "probability": 6
+            },
+            "lump-in-throat": {
+                "slug": "lump-in-throat",
+                "probability": 6
+            },
+            "too-little-hair": {
+                "slug": "too-little-hair",
+                "probability": 3
+            },
+            "drainage-in-throat": {
+                "slug": "drainage-in-throat",
+                "probability": 3
+            },
+            "double-vision": {
+                "slug": "double-vision",
+                "probability": 3
+            },
+            "throat-feels-tight": {
+                "slug": "throat-feels-tight",
+                "probability": 3
+            },
+            "blindness": {
+                "slug": "blindness",
+                "probability": 3
+            },
+            "restlessness": {
+                "slug": "restlessness",
+                "probability": 3
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -28527,9 +30030,58 @@
     "thyroid-nodule": {
         "condition_name": "Thyroid nodule",
         "condition_slug": "thyroid-nodule",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Thyroid nodules are lumps which commonly arise within an otherwise normal thyroid gland. They indicate a thyroid neoplasm, but only a small percentage of these are thyroid cancers.",
+        "condition_remarks": "Within all the people who go to their doctor with thyroid nodule, 29% report having difficulty in swallowing, 26% report having fatigue, and 21% report having neck mass. The symptoms that are highly suggestive of thyroid nodule are difficulty in swallowing, neck mass, throat feels tight, neck swelling, lump in throat, and back weakness, although you may still have thyroid nodule without those symptoms.",
+        "symptoms": {
+            "difficulty-in-swallowing": {
+                "slug": "difficulty-in-swallowing",
+                "probability": 29
+            },
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 26
+            },
+            "neck-mass": {
+                "slug": "neck-mass",
+                "probability": 21
+            },
+            "throat-feels-tight": {
+                "slug": "throat-feels-tight",
+                "probability": 18
+            },
+            "hoarse-voice": {
+                "slug": "hoarse-voice",
+                "probability": 12
+            },
+            "neck-swelling": {
+                "slug": "neck-swelling",
+                "probability": 12
+            },
+            "lump-in-throat": {
+                "slug": "lump-in-throat",
+                "probability": 12
+            },
+            "sleepiness": {
+                "slug": "sleepiness",
+                "probability": 8
+            },
+            "weight-gain": {
+                "slug": "weight-gain",
+                "probability": 8
+            },
+            "diminished-hearing": {
+                "slug": "diminished-hearing",
+                "probability": 8
+            },
+            "abnormal-movement-of-eyelid": {
+                "slug": "abnormal-movement-of-eyelid",
+                "probability": 4
+            },
+            "back-weakness": {
+                "slug": "back-weakness",
+                "probability": 4
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -28610,9 +30162,58 @@
     "tic-movement-disorder": {
         "condition_name": "Tic (movement) disorder",
         "condition_slug": "tic-movement-disorder",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Disorders characterized by recurrent TICS that may interfere with speech and other activities. Tics are sudden, rapid, nonrhythmic, stereotyped motor movements or vocalizations which may be exacerbated by stress and are generally attenuated during absorbing activities. Tic disorders are distinguished from conditions which feature other types of abnormal movements that may accompany general medical conditions. (From DSM-IV, 1994)",
+        "condition_remarks": "Within all the people who go to their doctor with tic (movement) disorder, 90% report having abnormal involuntary movements, 49% report having headache, and 36% report having abnormal movement of eyelid. The symptoms that are highly suggestive of tic (movement) disorder are abnormal involuntary movements, abnormal movement of eyelid, and stiffness all over, although you may still have tic (movement) disorder without those symptoms.",
+        "symptoms": {
+            "abnormal-involuntary-movements": {
+                "slug": "abnormal-involuntary-movements",
+                "probability": 90
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 49
+            },
+            "abnormal-movement-of-eyelid": {
+                "slug": "abnormal-movement-of-eyelid",
+                "probability": 36
+            },
+            "seizures": {
+                "slug": "seizures",
+                "probability": 25
+            },
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 25
+            },
+            "symptoms-of-eye": {
+                "slug": "symptoms-of-eye",
+                "probability": 18
+            },
+            "problems-with-movement": {
+                "slug": "problems-with-movement",
+                "probability": 10
+            },
+            "cramps-and-spasms": {
+                "slug": "cramps-and-spasms",
+                "probability": 10
+            },
+            "excessive-anger": {
+                "slug": "excessive-anger",
+                "probability": 10
+            },
+            "stiffness-all-over": {
+                "slug": "stiffness-all-over",
+                "probability": 10
+            },
+            "groin-pain": {
+                "slug": "groin-pain",
+                "probability": 10
+            },
+            "temper-problems": {
+                "slug": "temper-problems",
+                "probability": 10
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -28693,9 +30294,58 @@
     "tietze-syndrome": {
         "condition_name": "Tietze syndrome",
         "condition_slug": "tietze-syndrome",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Tietze syndrome is a benign inflammation of one or more of the costal cartilages. It was first described in 1921 by the German surgeon Alexander Tietze (1864\u20131927).",
+        "condition_remarks": "Within all the people who go to their doctor with tietze syndrome, 94% report having sharp chest pain, 51% report having rib pain, and 49% report having shortness of breath. The symptoms that are highly suggestive of tietze syndrome are sharp chest pain, rib pain, hurts to breath, and pain or soreness of breast, although you may still have tietze syndrome without those symptoms.",
+        "symptoms": {
+            "sharp-chest-pain": {
+                "slug": "sharp-chest-pain",
+                "probability": 94
+            },
+            "rib-pain": {
+                "slug": "rib-pain",
+                "probability": 51
+            },
+            "shortness-of-breath": {
+                "slug": "shortness-of-breath",
+                "probability": 49
+            },
+            "cough": {
+                "slug": "cough",
+                "probability": 41
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 41
+            },
+            "chest-tightness": {
+                "slug": "chest-tightness",
+                "probability": 35
+            },
+            "side-pain": {
+                "slug": "side-pain",
+                "probability": 27
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 27
+            },
+            "hurts-to-breath": {
+                "slug": "hurts-to-breath",
+                "probability": 22
+            },
+            "difficulty-breathing": {
+                "slug": "difficulty-breathing",
+                "probability": 22
+            },
+            "pain-or-soreness-of-breast": {
+                "slug": "pain-or-soreness-of-breast",
+                "probability": 22
+            },
+            "loss-of-sensation": {
+                "slug": "loss-of-sensation",
+                "probability": 21
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -28776,9 +30426,58 @@
     "tinnitus-of-unknown-cause": {
         "condition_name": "Tinnitus of unknown cause",
         "condition_slug": "tinnitus-of-unknown-cause",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "NIH: National Institute on Deafness and Other Communication Disorders",
+        "condition_remarks": "Within all the people who go to their doctor with tinnitus of unknown cause, 91% report having ringing in ear, 69% report having diminished hearing, and 60% report having dizziness. The symptoms that are highly suggestive of tinnitus of unknown cause are ringing in ear, diminished hearing, plugged feeling in ear, and itchy ear(s), although you may still have tinnitus of unknown cause without those symptoms.",
+        "symptoms": {
+            "ringing-in-ear": {
+                "slug": "ringing-in-ear",
+                "probability": 91
+            },
+            "diminished-hearing": {
+                "slug": "diminished-hearing",
+                "probability": 69
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 60
+            },
+            "ear-pain": {
+                "slug": "ear-pain",
+                "probability": 41
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 37
+            },
+            "plugged-feeling-in-ear": {
+                "slug": "plugged-feeling-in-ear",
+                "probability": 34
+            },
+            "itchy-ear-s": {
+                "slug": "itchy-ear-s",
+                "probability": 9
+            },
+            "frontal-headache": {
+                "slug": "frontal-headache",
+                "probability": 9
+            },
+            "symptoms-of-eye": {
+                "slug": "symptoms-of-eye",
+                "probability": 6
+            },
+            "hoarse-voice": {
+                "slug": "hoarse-voice",
+                "probability": 6
+            },
+            "fluid-in-ear": {
+                "slug": "fluid-in-ear",
+                "probability": 6
+            },
+            "neck-stiffness-or-tightness": {
+                "slug": "neck-stiffness-or-tightness",
+                "probability": 6
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -28859,9 +30558,58 @@
     "tonsillar-hypertrophy": {
         "condition_name": "Tonsillar hypertrophy",
         "condition_slug": "tonsillar-hypertrophy",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Palatine tonsils, occasionally called the faucial tonsils, are the tonsils that can be seen on the left and right sides at the back of the throat.",
+        "condition_remarks": "Within all the people who go to their doctor with tonsillar hypertrophy, 71% report having swollen or red tonsils, 71% report having abnormal breathing sounds, and 56% report having sore throat. The symptoms that are highly suggestive of tonsillar hypertrophy are swollen or red tonsils, abnormal breathing sounds, apnea, redness in ear, hurts to breath, and drainage in throat, although you may still have tonsillar hypertrophy without those symptoms.",
+        "symptoms": {
+            "swollen-or-red-tonsils": {
+                "slug": "swollen-or-red-tonsils",
+                "probability": 71
+            },
+            "abnormal-breathing-sounds": {
+                "slug": "abnormal-breathing-sounds",
+                "probability": 71
+            },
+            "sore-throat": {
+                "slug": "sore-throat",
+                "probability": 56
+            },
+            "nasal-congestion": {
+                "slug": "nasal-congestion",
+                "probability": 46
+            },
+            "apnea": {
+                "slug": "apnea",
+                "probability": 42
+            },
+            "cough": {
+                "slug": "cough",
+                "probability": 40
+            },
+            "redness-in-ear": {
+                "slug": "redness-in-ear",
+                "probability": 30
+            },
+            "hurts-to-breath": {
+                "slug": "hurts-to-breath",
+                "probability": 29
+            },
+            "fever": {
+                "slug": "fever",
+                "probability": 29
+            },
+            "drainage-in-throat": {
+                "slug": "drainage-in-throat",
+                "probability": 17
+            },
+            "allergic-reaction": {
+                "slug": "allergic-reaction",
+                "probability": 17
+            },
+            "difficulty-in-swallowing": {
+                "slug": "difficulty-in-swallowing",
+                "probability": 17
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -28942,9 +30690,58 @@
     "tonsillitis": {
         "condition_name": "Tonsillitis",
         "condition_slug": "tonsillitis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Tonsillitis is inflammation of the tonsils most commonly caused by viral or bacterial infection. Symptoms may include sore throat and fever. When caused by a bacterium belonging to the group A streptococcus, it is typically referred to as strep throat. The overwhelming majority of people recover completely with or without medication. In 40%, symptoms will resolve in three days, and within one week in 85% of people, regardless of whether streptococcal infection is present or not.",
+        "condition_remarks": "Within all the people who go to their doctor with tonsillitis, 75% report having sore throat, 62% report having swollen or red tonsils, and 48% report having abnormal breathing sounds. The symptoms that are highly suggestive of tonsillitis are swollen or red tonsils, abnormal breathing sounds, throat feels tight, redness in ear, drainage in throat, lump in throat, and throat redness, although you may still have tonsillitis without those symptoms.",
+        "symptoms": {
+            "sore-throat": {
+                "slug": "sore-throat",
+                "probability": 75
+            },
+            "swollen-or-red-tonsils": {
+                "slug": "swollen-or-red-tonsils",
+                "probability": 62
+            },
+            "abnormal-breathing-sounds": {
+                "slug": "abnormal-breathing-sounds",
+                "probability": 48
+            },
+            "nasal-congestion": {
+                "slug": "nasal-congestion",
+                "probability": 37
+            },
+            "throat-feels-tight": {
+                "slug": "throat-feels-tight",
+                "probability": 32
+            },
+            "redness-in-ear": {
+                "slug": "redness-in-ear",
+                "probability": 30
+            },
+            "apnea": {
+                "slug": "apnea",
+                "probability": 17
+            },
+            "diminished-hearing": {
+                "slug": "diminished-hearing",
+                "probability": 17
+            },
+            "drainage-in-throat": {
+                "slug": "drainage-in-throat",
+                "probability": 13
+            },
+            "allergic-reaction": {
+                "slug": "allergic-reaction",
+                "probability": 13
+            },
+            "lump-in-throat": {
+                "slug": "lump-in-throat",
+                "probability": 13
+            },
+            "throat-redness": {
+                "slug": "throat-redness",
+                "probability": 9
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -29025,9 +30822,58 @@
     "tooth-abscess": {
         "condition_name": "Tooth abscess",
         "condition_slug": "tooth-abscess",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A tooth abscess or root abscess is pus enclosed in the tissues of the jaw bone at the apex of an infected tooth's root(s). Usually the abscess originates from a bacterial infection that has accumulated in the soft, often dead, pulp of the tooth. This can be caused by tooth decay, broken teeth or extensive periodontal disease (or combinations of these factors). A failed root canal treatment may also create a similar abscess.",
+        "condition_remarks": "Within all the people who go to their doctor with tooth abscess, 93% report having toothache, 57% report having peripheral edema, and 52% report having facial pain. The symptoms that are highly suggestive of tooth abscess are toothache, peripheral edema, facial pain, jaw swelling, gum pain, mouth pain, and pain in gums, although you may still have tooth abscess without those symptoms.",
+        "symptoms": {
+            "toothache": {
+                "slug": "toothache",
+                "probability": 93
+            },
+            "peripheral-edema": {
+                "slug": "peripheral-edema",
+                "probability": 57
+            },
+            "facial-pain": {
+                "slug": "facial-pain",
+                "probability": 52
+            },
+            "jaw-swelling": {
+                "slug": "jaw-swelling",
+                "probability": 41
+            },
+            "gum-pain": {
+                "slug": "gum-pain",
+                "probability": 40
+            },
+            "mouth-pain": {
+                "slug": "mouth-pain",
+                "probability": 26
+            },
+            "skin-swelling": {
+                "slug": "skin-swelling",
+                "probability": 18
+            },
+            "fluid-retention": {
+                "slug": "fluid-retention",
+                "probability": 18
+            },
+            "pain-in-gums": {
+                "slug": "pain-in-gums",
+                "probability": 13
+            },
+            "lip-swelling": {
+                "slug": "lip-swelling",
+                "probability": 9
+            },
+            "neck-swelling": {
+                "slug": "neck-swelling",
+                "probability": 6
+            },
+            "symptoms-of-the-face": {
+                "slug": "symptoms-of-the-face",
+                "probability": 6
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -29108,9 +30954,58 @@
     "tooth-disorder": {
         "condition_name": "Tooth disorder",
         "condition_slug": "tooth-disorder",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "The most familiar symptom of a tooth problem is a toothache. Others include worn-down or loose teeth. It's important that you see a dentist if you have any problems with your teeth. Fortunately, you can prevent many tooth disorders by taking care of your teeth and keeping them clean.",
+        "condition_remarks": "Within all the people who go to their doctor with tooth disorder, 96% report having toothache, 44% report having facial pain, and 37% report having gum pain. The symptoms that are highly suggestive of tooth disorder are toothache, facial pain, gum pain, mouth pain, jaw swelling, pain in gums, and bleeding gums, although you may still have tooth disorder without those symptoms.",
+        "symptoms": {
+            "toothache": {
+                "slug": "toothache",
+                "probability": 96
+            },
+            "facial-pain": {
+                "slug": "facial-pain",
+                "probability": 44
+            },
+            "gum-pain": {
+                "slug": "gum-pain",
+                "probability": 37
+            },
+            "ear-pain": {
+                "slug": "ear-pain",
+                "probability": 31
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 26
+            },
+            "mouth-pain": {
+                "slug": "mouth-pain",
+                "probability": 22
+            },
+            "peripheral-edema": {
+                "slug": "peripheral-edema",
+                "probability": 22
+            },
+            "jaw-swelling": {
+                "slug": "jaw-swelling",
+                "probability": 13
+            },
+            "pain-in-gums": {
+                "slug": "pain-in-gums",
+                "probability": 11
+            },
+            "bleeding-gums": {
+                "slug": "bleeding-gums",
+                "probability": 4
+            },
+            "mouth-ulcer": {
+                "slug": "mouth-ulcer",
+                "probability": 3
+            },
+            "swollen-lymph-nodes": {
+                "slug": "swollen-lymph-nodes",
+                "probability": 3
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -29191,9 +31086,58 @@
     "torticollis": {
         "condition_name": "Torticollis",
         "condition_slug": "torticollis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Torticollis, also known as wry neck or loxia, is a symptom defined by an abnormal, asymmetrical head or neck position, which may be due to a variety of causes. The term torticollis is derived from the Latin words tortus for twisted and collum for neck.",
+        "condition_remarks": "Within all the people who go to their doctor with torticollis, 89% report having neck pain, 51% report having neck stiffness or tightness, and 50% report having headache. The symptoms that are highly suggestive of torticollis are neck pain, neck stiffness or tightness, neck cramps or spasms, and shoulder lump or mass, although you may still have torticollis without those symptoms.",
+        "symptoms": {
+            "neck-pain": {
+                "slug": "neck-pain",
+                "probability": 89
+            },
+            "neck-stiffness-or-tightness": {
+                "slug": "neck-stiffness-or-tightness",
+                "probability": 51
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 50
+            },
+            "neck-cramps-or-spasms": {
+                "slug": "neck-cramps-or-spasms",
+                "probability": 47
+            },
+            "shoulder-pain": {
+                "slug": "shoulder-pain",
+                "probability": 33
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 27
+            },
+            "arm-pain": {
+                "slug": "arm-pain",
+                "probability": 27
+            },
+            "abnormal-involuntary-movements": {
+                "slug": "abnormal-involuntary-movements",
+                "probability": 21
+            },
+            "throat-swelling": {
+                "slug": "throat-swelling",
+                "probability": 4
+            },
+            "cramps-and-spasms": {
+                "slug": "cramps-and-spasms",
+                "probability": 4
+            },
+            "leg-weakness": {
+                "slug": "leg-weakness",
+                "probability": 4
+            },
+            "shoulder-lump-or-mass": {
+                "slug": "shoulder-lump-or-mass",
+                "probability": 4
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -29274,9 +31218,58 @@
     "tourette-syndrome": {
         "condition_name": "Tourette syndrome",
         "condition_slug": "tourette-syndrome",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Tourette syndrome (also called Tourette's syndrome, Tourette's disorder, Gilles de la Tourette syndrome, GTS or, more commonly, simply Tourette's or TS) is an inherited neuropsychiatric disorder with onset in childhood, characterized by multiple physical (motor) tics and at least one vocal (phonic) tic. These tics characteristically wax and wane, can be suppressed temporarily, and are preceded by a premonitory urge. Tourette's is defined as part of a spectrum of tic disorders, which includes provisional, transient and persistent (chronic) tics.",
+        "condition_remarks": "Within all the people who go to their doctor with tourette syndrome, 77% report having abnormal involuntary movements, 33% report having depressive or psychotic symptoms, and 27% report having headache. The symptoms that are highly suggestive of tourette syndrome are abnormal involuntary movements, abnormal movement of eyelid, and obsessions and compulsions, although you may still have tourette syndrome without those symptoms.",
+        "symptoms": {
+            "abnormal-involuntary-movements": {
+                "slug": "abnormal-involuntary-movements",
+                "probability": 77
+            },
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 33
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 27
+            },
+            "allergic-reaction": {
+                "slug": "allergic-reaction",
+                "probability": 20
+            },
+            "drug-abuse": {
+                "slug": "drug-abuse",
+                "probability": 11
+            },
+            "sleepiness": {
+                "slug": "sleepiness",
+                "probability": 11
+            },
+            "abnormal-movement-of-eyelid": {
+                "slug": "abnormal-movement-of-eyelid",
+                "probability": 11
+            },
+            "excessive-anger": {
+                "slug": "excessive-anger",
+                "probability": 11
+            },
+            "delusions-or-hallucinations": {
+                "slug": "delusions-or-hallucinations",
+                "probability": 11
+            },
+            "obsessions-and-compulsions": {
+                "slug": "obsessions-and-compulsions",
+                "probability": 11
+            },
+            "temper-problems": {
+                "slug": "temper-problems",
+                "probability": 11
+            },
+            "warts": {
+                "slug": "warts",
+                "probability": 11
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -29357,9 +31350,58 @@
     "toxic-multinodular-goiter": {
         "condition_name": "Toxic multinodular goiter",
         "condition_slug": "toxic-multinodular-goiter",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Toxic multinodular goiter (also known as toxic nodular goiter, toxic nodular struma) is a common cause of hyperthyroidism in which there is excess production of thyroid hormones from functionally autonomous thyroid nodules, which do not require stimulation from thyroid stimulating hormone (TSH).",
+        "condition_remarks": "Within all the people who go to their doctor with toxic multinodular goiter, 27% report having fatigue, 19% report having abnormal involuntary movements, and 15% report having double vision. The symptoms that are highly suggestive of toxic multinodular goiter are double vision, abnormal movement of eyelid, and foreign body sensation in eye, although you may still have toxic multinodular goiter without those symptoms.",
+        "symptoms": {
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 27
+            },
+            "abnormal-involuntary-movements": {
+                "slug": "abnormal-involuntary-movements",
+                "probability": 19
+            },
+            "double-vision": {
+                "slug": "double-vision",
+                "probability": 15
+            },
+            "sweating": {
+                "slug": "sweating",
+                "probability": 15
+            },
+            "involuntary-urination": {
+                "slug": "involuntary-urination",
+                "probability": 11
+            },
+            "abnormal-movement-of-eyelid": {
+                "slug": "abnormal-movement-of-eyelid",
+                "probability": 11
+            },
+            "foreign-body-sensation-in-eye": {
+                "slug": "foreign-body-sensation-in-eye",
+                "probability": 11
+            },
+            "spots-or-clouds-in-vision": {
+                "slug": "spots-or-clouds-in-vision",
+                "probability": 6
+            },
+            "leg-cramps-or-spasms": {
+                "slug": "leg-cramps-or-spasms",
+                "probability": 6
+            },
+            "irregular-heartbeat": {
+                "slug": "irregular-heartbeat",
+                "probability": 6
+            },
+            "sinus-congestion": {
+                "slug": "sinus-congestion",
+                "probability": 6
+            },
+            "neck-swelling": {
+                "slug": "neck-swelling",
+                "probability": 6
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -29440,9 +31482,58 @@
     "toxoplasmosis": {
         "condition_name": "Toxoplasmosis",
         "condition_slug": "toxoplasmosis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Toxoplasmosis is a parasitic disease caused by the protozoan Toxoplasma gondii. The parasite infects most genera of warm-blooded animals, including humans, but the primary host is the felid (cat) family. Animals are infected by eating infected meat, by ingestion of feces of a cat that has itself recently been infected, or by transmission from mother to fetus. Cats are the primary source of infection to human hosts, although contact with raw meat, especially pork, is a more significant source of human infections in some countries. Fecal contamination of hands is a significant risk factor.",
+        "condition_remarks": "Within all the people who go to their doctor with toxoplasmosis, 49% report having itchy scalp, 49% report having blindness, and 49% report having irregular appearing scalp. The symptoms that are highly suggestive of toxoplasmosis are eye redness, itchy scalp, blindness, irregular appearing scalp, elbow weakness, cross-eyed, excessive growth, bowlegged or knock-kneed, feeling hot and cold, wrist weakness, and emotional symptoms, although you may still have toxoplasmosis without those symptoms.",
+        "symptoms": {
+            "eye-redness": {
+                "slug": "eye-redness",
+                "probability": 49
+            },
+            "diminished-vision": {
+                "slug": "diminished-vision",
+                "probability": 49
+            },
+            "itchy-scalp": {
+                "slug": "itchy-scalp",
+                "probability": 49
+            },
+            "blindness": {
+                "slug": "blindness",
+                "probability": 49
+            },
+            "irregular-appearing-scalp": {
+                "slug": "irregular-appearing-scalp",
+                "probability": 49
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 4
+            },
+            "cross-eyed": {
+                "slug": "cross-eyed",
+                "probability": 4
+            },
+            "excessive-growth": {
+                "slug": "excessive-growth",
+                "probability": 4
+            },
+            "bowlegged-or-knock-kneed": {
+                "slug": "bowlegged-or-knock-kneed",
+                "probability": 4
+            },
+            "feeling-hot-and-cold": {
+                "slug": "feeling-hot-and-cold",
+                "probability": 4
+            },
+            "wrist-weakness": {
+                "slug": "wrist-weakness",
+                "probability": 4
+            },
+            "emotional-symptoms": {
+                "slug": "emotional-symptoms",
+                "probability": 4
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -29523,9 +31614,58 @@
     "tracheitis": {
         "condition_name": "Tracheitis",
         "condition_slug": "tracheitis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Tracheitis is an inflammation of the trachea.",
+        "condition_remarks": "Within all the people who go to their doctor with tracheitis, 90% report having cough, 75% report having sore throat, and 64% report having fever. The symptoms that are highly suggestive of tracheitis are hoarse voice, plugged feeling in ear, and sneezing, although you may still have tracheitis without those symptoms.",
+        "symptoms": {
+            "cough": {
+                "slug": "cough",
+                "probability": 90
+            },
+            "sore-throat": {
+                "slug": "sore-throat",
+                "probability": 75
+            },
+            "fever": {
+                "slug": "fever",
+                "probability": 64
+            },
+            "coryza": {
+                "slug": "coryza",
+                "probability": 48
+            },
+            "hoarse-voice": {
+                "slug": "hoarse-voice",
+                "probability": 48
+            },
+            "nasal-congestion": {
+                "slug": "nasal-congestion",
+                "probability": 42
+            },
+            "ear-pain": {
+                "slug": "ear-pain",
+                "probability": 42
+            },
+            "difficulty-breathing": {
+                "slug": "difficulty-breathing",
+                "probability": 42
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 42
+            },
+            "plugged-feeling-in-ear": {
+                "slug": "plugged-feeling-in-ear",
+                "probability": 35
+            },
+            "shortness-of-breath": {
+                "slug": "shortness-of-breath",
+                "probability": 35
+            },
+            "sneezing": {
+                "slug": "sneezing",
+                "probability": 15
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -29606,9 +31746,58 @@
     "transient-ischemic-attack": {
         "condition_name": "Transient ischemic attack",
         "condition_slug": "transient-ischemic-attack",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A transient ischemic attack (TIA) is a transient episode of neurologic dysfunction caused by ischemia (loss of blood flow) \u2013 either focal brain, spinal cord or retinal \u2013 without acute infarction (tissue death).",
+        "condition_remarks": "Within all the people who go to their doctor with transient ischemic attack, 62% report having loss of sensation, 53% report having dizziness, and 51% report having headache. The symptoms that are highly suggestive of transient ischemic attack are loss of sensation, focal weakness, slurring words, difficulty speaking, symptoms of the face, and disturbance of memory, although you may still have transient ischemic attack without those symptoms.",
+        "symptoms": {
+            "loss-of-sensation": {
+                "slug": "loss-of-sensation",
+                "probability": 62
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 53
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 51
+            },
+            "weakness": {
+                "slug": "weakness",
+                "probability": 46
+            },
+            "focal-weakness": {
+                "slug": "focal-weakness",
+                "probability": 40
+            },
+            "slurring-words": {
+                "slug": "slurring-words",
+                "probability": 40
+            },
+            "difficulty-speaking": {
+                "slug": "difficulty-speaking",
+                "probability": 33
+            },
+            "symptoms-of-the-face": {
+                "slug": "symptoms-of-the-face",
+                "probability": 31
+            },
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 29
+            },
+            "diminished-vision": {
+                "slug": "diminished-vision",
+                "probability": 29
+            },
+            "disturbance-of-memory": {
+                "slug": "disturbance-of-memory",
+                "probability": 25
+            },
+            "paresthesia": {
+                "slug": "paresthesia",
+                "probability": 24
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -29689,9 +31878,58 @@
     "trichiasis": {
         "condition_name": "Trichiasis",
         "condition_slug": "trichiasis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Trichiasis is a medical term for abnormally positioned eyelashes that grow back toward the eye, touching the cornea or conjunctiva. This can be caused by infection, inflammation, autoimmune conditions, congenital defects, eyelid agenesis and trauma such as burns or eyelid injury.",
+        "condition_remarks": "Within all the people who go to their doctor with trichiasis, 80% report having foreign body sensation in eye, 63% report having eyelid lesion or rash, and 44% report having itchiness of eye. The symptoms that are highly suggestive of trichiasis are foreign body sensation in eye, eyelid lesion or rash, symptoms of eye, itchiness of eye, pain in eye, swollen eye, emotional symptoms, back weakness, elbow cramps or spasms, and pus in sputum, although you may still have trichiasis without those symptoms.",
+        "symptoms": {
+            "foreign-body-sensation-in-eye": {
+                "slug": "foreign-body-sensation-in-eye",
+                "probability": 80
+            },
+            "eyelid-lesion-or-rash": {
+                "slug": "eyelid-lesion-or-rash",
+                "probability": 63
+            },
+            "diminished-vision": {
+                "slug": "diminished-vision",
+                "probability": 44
+            },
+            "symptoms-of-eye": {
+                "slug": "symptoms-of-eye",
+                "probability": 44
+            },
+            "itchiness-of-eye": {
+                "slug": "itchiness-of-eye",
+                "probability": 44
+            },
+            "pain-in-eye": {
+                "slug": "pain-in-eye",
+                "probability": 44
+            },
+            "eye-redness": {
+                "slug": "eye-redness",
+                "probability": 28
+            },
+            "swollen-eye": {
+                "slug": "swollen-eye",
+                "probability": 28
+            },
+            "emotional-symptoms": {
+                "slug": "emotional-symptoms",
+                "probability": 2
+            },
+            "back-weakness": {
+                "slug": "back-weakness",
+                "probability": 2
+            },
+            "elbow-cramps-or-spasms": {
+                "slug": "elbow-cramps-or-spasms",
+                "probability": 2
+            },
+            "pus-in-sputum": {
+                "slug": "pus-in-sputum",
+                "probability": 2
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -29772,9 +32010,58 @@
     "trichinosis": {
         "condition_name": "Trichinosis",
         "condition_slug": "trichinosis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Trichinosis, also called trichinellosis, or trichiniasis, is a parasitic disease caused by eating raw or undercooked pork or wild game infected with the larvae of a species of roundworm Trichinella spiralis, commonly called the trichina worm. There are eight Trichinella species; five are encapsulated and three are not. Only three Trichinella species are known to cause trichinosis: T. spiralis, T. nativa, and T. britovi.",
+        "condition_remarks": "Within all the people who go to their doctor with trichinosis, 84% report having painful urination, 84% report having skin rash, and 84% report having nasal congestion. The symptoms that are highly suggestive of trichinosis are painful urination, skin rash, nasal congestion, pelvic pressure, vulvar sore, knee lump or mass, neck cramps or spasms, excessive growth, shoulder swelling, loss of sex drive, and bedwetting, although you may still have trichinosis without those symptoms.",
+        "symptoms": {
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 84
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 84
+            },
+            "skin-rash": {
+                "slug": "skin-rash",
+                "probability": 84
+            },
+            "nasal-congestion": {
+                "slug": "nasal-congestion",
+                "probability": 84
+            },
+            "pelvic-pressure": {
+                "slug": "pelvic-pressure",
+                "probability": 14
+            },
+            "vulvar-sore": {
+                "slug": "vulvar-sore",
+                "probability": 14
+            },
+            "knee-lump-or-mass": {
+                "slug": "knee-lump-or-mass",
+                "probability": 14
+            },
+            "neck-cramps-or-spasms": {
+                "slug": "neck-cramps-or-spasms",
+                "probability": 14
+            },
+            "excessive-growth": {
+                "slug": "excessive-growth",
+                "probability": 14
+            },
+            "shoulder-swelling": {
+                "slug": "shoulder-swelling",
+                "probability": 14
+            },
+            "loss-of-sex-drive": {
+                "slug": "loss-of-sex-drive",
+                "probability": 14
+            },
+            "bedwetting": {
+                "slug": "bedwetting",
+                "probability": 14
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -29855,9 +32142,58 @@
     "trichomonas-infection": {
         "condition_name": "Trichomonas infection",
         "condition_slug": "trichomonas-infection",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Trichomonas is a genus of anaerobic protists that are parasites of vertebrates. They are included with the parabasalids.",
+        "condition_remarks": "Within all the people who go to their doctor with trichomonas infection, 74% report having vaginal discharge, 69% report having sharp abdominal pain, and 35% report having pelvic pain. The symptoms that are highly suggestive of trichomonas infection are vaginal discharge, pelvic pain, vaginal itching, and unpredictable menstruation, although you may still have trichomonas infection without those symptoms.",
+        "symptoms": {
+            "vaginal-discharge": {
+                "slug": "vaginal-discharge",
+                "probability": 74
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 69
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 35
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 35
+            },
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 35
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 32
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 28
+            },
+            "vaginal-itching": {
+                "slug": "vaginal-itching",
+                "probability": 25
+            },
+            "burning-abdominal-pain": {
+                "slug": "burning-abdominal-pain",
+                "probability": 25
+            },
+            "side-pain": {
+                "slug": "side-pain",
+                "probability": 21
+            },
+            "pain-during-pregnancy": {
+                "slug": "pain-during-pregnancy",
+                "probability": 21
+            },
+            "unpredictable-menstruation": {
+                "slug": "unpredictable-menstruation",
+                "probability": 16
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -29938,9 +32274,58 @@
     "tricuspid-valve-disease": {
         "condition_name": "Tricuspid valve disease",
         "condition_slug": "tricuspid-valve-disease",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Tricuspid valve disease is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with tricuspid valve disease, 51% report having drainage in throat, 51% report having anxiety and nervousness, and 51% report having back pain. The symptoms that are highly suggestive of tricuspid valve disease are drainage in throat, excessive growth, itchy eyelid, cross-eyed, wrist weakness, elbow weakness, elbow cramps or spasms, emotional symptoms, hip stiffness or tightness, and nailbiting, although you may still have tricuspid valve disease without those symptoms.",
+        "symptoms": {
+            "anxiety-and-nervousness": {
+                "slug": "anxiety-and-nervousness",
+                "probability": 51
+            },
+            "drainage-in-throat": {
+                "slug": "drainage-in-throat",
+                "probability": 51
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 51
+            },
+            "excessive-growth": {
+                "slug": "excessive-growth",
+                "probability": 4
+            },
+            "itchy-eyelid": {
+                "slug": "itchy-eyelid",
+                "probability": 4
+            },
+            "cross-eyed": {
+                "slug": "cross-eyed",
+                "probability": 4
+            },
+            "wrist-weakness": {
+                "slug": "wrist-weakness",
+                "probability": 4
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 4
+            },
+            "elbow-cramps-or-spasms": {
+                "slug": "elbow-cramps-or-spasms",
+                "probability": 4
+            },
+            "emotional-symptoms": {
+                "slug": "emotional-symptoms",
+                "probability": 4
+            },
+            "hip-stiffness-or-tightness": {
+                "slug": "hip-stiffness-or-tightness",
+                "probability": 4
+            },
+            "nailbiting": {
+                "slug": "nailbiting",
+                "probability": 4
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -30021,9 +32406,58 @@
     "trigeminal-neuralgia": {
         "condition_name": "Trigeminal neuralgia",
         "condition_slug": "trigeminal-neuralgia",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Trigeminal neuralgia (TN, or TGN), also known as prosopalgia, suicide disease, or Fothergill's disease is a neuropathic disorder characterized by episodes of intense pain in the face, originating from the trigeminal nerve. The clinical association between TN and hemifacial spasm is the so-called tic douloureux. It has been described as among the most painful conditions known to mankind. It is estimated that 1 in 15,000 or 20,000 people suffer from TN, although the actual figure may be significantly higher due to frequent misdiagnosis. In a majority of cases, TN symptoms begin appearing more frequently over the age of 50, although there have been cases with patients being as young as three years of age. It is more common in females than males.",
+        "condition_remarks": "Within all the people who go to their doctor with trigeminal neuralgia, 90% report having facial pain, 64% report having headache, and 29% report having loss of sensation. The symptoms that are highly suggestive of trigeminal neuralgia are facial pain, symptoms of the face, and tongue pain, although you may still have trigeminal neuralgia without those symptoms.",
+        "symptoms": {
+            "facial-pain": {
+                "slug": "facial-pain",
+                "probability": 90
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 64
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 29
+            },
+            "loss-of-sensation": {
+                "slug": "loss-of-sensation",
+                "probability": 29
+            },
+            "symptoms-of-the-face": {
+                "slug": "symptoms-of-the-face",
+                "probability": 25
+            },
+            "ache-all-over": {
+                "slug": "ache-all-over",
+                "probability": 25
+            },
+            "pain-in-eye": {
+                "slug": "pain-in-eye",
+                "probability": 21
+            },
+            "toothache": {
+                "slug": "toothache",
+                "probability": 17
+            },
+            "paresthesia": {
+                "slug": "paresthesia",
+                "probability": 12
+            },
+            "abnormal-involuntary-movements": {
+                "slug": "abnormal-involuntary-movements",
+                "probability": 12
+            },
+            "swollen-eye": {
+                "slug": "swollen-eye",
+                "probability": 12
+            },
+            "tongue-pain": {
+                "slug": "tongue-pain",
+                "probability": 12
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -30104,9 +32538,58 @@
     "trigger-finger-finger-disorder": {
         "condition_name": "Trigger finger (finger disorder)",
         "condition_slug": "trigger-finger-finger-disorder",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A painful disability in the hand affecting the finger or thumb. It is caused by mechanical impingement of the digital flexor tendons as they pass through a narrowed retinacular pulley at the level of the metacarpal head. Thickening of the sheath and fibrocartilaginous metaplasia can occur, and nodules can form. (From Green's Operative Hand Surgery, 5th ed, p2137-58).",
+        "condition_remarks": "Within all the people who go to their doctor with trigger finger (finger disorder), 83% report having hand or finger pain, 69% report having hand or finger stiffness or tightness, and 33% report having wrist pain. The symptoms that are highly suggestive of trigger finger (finger disorder) are hand or finger pain, hand or finger stiffness or tightness, hand or finger cramps or spasms, shoulder stiffness or tightness, bleeding from ear, muscle stiffness or tightness, and back stiffness or tightness, although you may still have trigger finger (finger disorder) without those symptoms.",
+        "symptoms": {
+            "hand-or-finger-pain": {
+                "slug": "hand-or-finger-pain",
+                "probability": 83
+            },
+            "hand-or-finger-stiffness-or-tightness": {
+                "slug": "hand-or-finger-stiffness-or-tightness",
+                "probability": 69
+            },
+            "wrist-pain": {
+                "slug": "wrist-pain",
+                "probability": 33
+            },
+            "hand-or-finger-cramps-or-spasms": {
+                "slug": "hand-or-finger-cramps-or-spasms",
+                "probability": 19
+            },
+            "hand-or-finger-swelling": {
+                "slug": "hand-or-finger-swelling",
+                "probability": 11
+            },
+            "paresthesia": {
+                "slug": "paresthesia",
+                "probability": 11
+            },
+            "shoulder-stiffness-or-tightness": {
+                "slug": "shoulder-stiffness-or-tightness",
+                "probability": 6
+            },
+            "bones-are-painful": {
+                "slug": "bones-are-painful",
+                "probability": 6
+            },
+            "bleeding-from-ear": {
+                "slug": "bleeding-from-ear",
+                "probability": 6
+            },
+            "muscle-stiffness-or-tightness": {
+                "slug": "muscle-stiffness-or-tightness",
+                "probability": 6
+            },
+            "back-stiffness-or-tightness": {
+                "slug": "back-stiffness-or-tightness",
+                "probability": 6
+            },
+            "skin-on-arm-or-hand-looks-infected": {
+                "slug": "skin-on-arm-or-hand-looks-infected",
+                "probability": 6
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -49488,9 +51971,9 @@
             }
         }
     },
-    "lymphedema--2": {
+    "lymphedema": {
         "condition_name": "Lymphedema",
-        "condition_slug": "lymphedema--2",
+        "condition_slug": "lymphedema",
         "condition_description": "Lymphedema (lymphoedema in British English), also known as lymphatic obstruction, is a condition of localized fluid retention and tissue swelling caused by a compromised lymphatic system. The lymphatic system returns the interstitial fluid to the thoracic duct and then to the bloodstream, where it is recirculated back to the tissues. Tissues with lymphedema are at risk of infection.",
         "condition_remarks": "Within all the people who go to their doctor with lymphedema, 56% report having skin lesion, 49% report having leg swelling, and 45% report having peripheral edema. The symptoms that are highly suggestive of lymphedema are leg swelling, peripheral edema, and lymphedema, although you may still have lymphedema without those symptoms.",
         "symptoms": {
@@ -88383,9 +90866,54 @@
     "tuberculosis": {
         "condition_name": "Tuberculosis",
         "condition_slug": "tuberculosis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Tuberculosis, MTB, or TB (short for tubercle bacillus) is a common, and in many cases lethal, infectious disease caused by various strains of mycobacteria, usually Mycobacterium tuberculosis. Tuberculosis typically attacks the lungs, but can also affect other parts of the body. It is spread through the air when people who have an active TB infection cough, sneeze, or otherwise transmit respiratory fluids through the air. Most infections are asymptomatic and latent, but about one in ten latent infections eventually progresses to active disease which, if left untreated, kills more than 50% of those so infected.",
+        "condition_remarks": "Within all the people who go to their doctor with tuberculosis, 33% report having cough, 31% report having shortness of breath, and 10% report having sweating. The symptoms that are highly suggestive of tuberculosis are back cramps or spasms, although you may still have tuberculosis without those symptoms.",
+        "symptoms": {
+            "cough": {
+                "slug": "cough",
+                "probability": 33
+            },
+            "shortness-of-breath": {
+                "slug": "shortness-of-breath",
+                "probability": 31
+            },
+            "sweating": {
+                "slug": "sweating",
+                "probability": 10
+            },
+            "congestion-in-chest": {
+                "slug": "congestion-in-chest",
+                "probability": 10
+            },
+            "hemoptysis": {
+                "slug": "hemoptysis",
+                "probability": 5
+            },
+            "skin-dryness-peeling-scaliness-or-roughness": {
+                "slug": "skin-dryness-peeling-scaliness-or-roughness",
+                "probability": 5
+            },
+            "drainage-in-throat": {
+                "slug": "drainage-in-throat",
+                "probability": 5
+            },
+            "hurts-to-breath": {
+                "slug": "hurts-to-breath",
+                "probability": 5
+            },
+            "itchiness-of-eye": {
+                "slug": "itchiness-of-eye",
+                "probability": 5
+            },
+            "back-cramps-or-spasms": {
+                "slug": "back-cramps-or-spasms",
+                "probability": 5
+            },
+            "vaginal-itching": {
+                "slug": "vaginal-itching",
+                "probability": 5
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -88466,9 +90994,58 @@
     "tuberous-sclerosis": {
         "condition_name": "Tuberous sclerosis",
         "condition_slug": "tuberous-sclerosis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Tuberous sclerosis or tuberous sclerosis complex (TSC) is a rare multi-system genetic disease that causes non-malignant tumors to grow in the brain and on other vital organs such as the kidneys, heart, eyes, lungs, and skin. A combination of symptoms may include seizures, developmental delay, behavioral problems, skin abnormalities, lung and kidney disease. TSC is caused by a mutation of either of two genes, TSC1 and TSC2, which code for the proteins hamartin and tuberin respectively. These proteins act as tumor growth suppressors, agents that regulate cell proliferation and differentiation.",
+        "condition_remarks": "Within all the people who go to their doctor with tuberous sclerosis, 85% report having seizures, 45% report having symptoms of the kidneys, and 45% report having difficulty speaking. The symptoms that are highly suggestive of tuberous sclerosis are seizures, cramps and spasms, delusions or hallucinations, symptoms of the kidneys, difficulty speaking, elbow weakness, underweight, excessive growth, low back weakness, and feeling hot and cold, although you may still have tuberous sclerosis without those symptoms.",
+        "symptoms": {
+            "seizures": {
+                "slug": "seizures",
+                "probability": 85
+            },
+            "cramps-and-spasms": {
+                "slug": "cramps-and-spasms",
+                "probability": 45
+            },
+            "delusions-or-hallucinations": {
+                "slug": "delusions-or-hallucinations",
+                "probability": 45
+            },
+            "symptoms-of-the-kidneys": {
+                "slug": "symptoms-of-the-kidneys",
+                "probability": 45
+            },
+            "shoulder-pain": {
+                "slug": "shoulder-pain",
+                "probability": 45
+            },
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 45
+            },
+            "difficulty-speaking": {
+                "slug": "difficulty-speaking",
+                "probability": 45
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 3
+            },
+            "underweight": {
+                "slug": "underweight",
+                "probability": 3
+            },
+            "excessive-growth": {
+                "slug": "excessive-growth",
+                "probability": 3
+            },
+            "low-back-weakness": {
+                "slug": "low-back-weakness",
+                "probability": 3
+            },
+            "feeling-hot-and-cold": {
+                "slug": "feeling-hot-and-cold",
+                "probability": 3
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -88549,9 +91126,58 @@
     "turner-syndrome": {
         "condition_name": "Turner syndrome",
         "condition_slug": "turner-syndrome",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Turner syndrome or Ullrich\u2013Turner syndrome (also known as \"Gonadal dysgenesis\":550), 45,X, encompasses several conditions in human females, of which monosomy X (absence of an entire sex chromosome, the Barr body) is most common. It is a chromosomal abnormality in which all or part of one of the sex chromosomes is absent or has other abnormalities (unaffected humans have 46 chromosomes, of which two are sex chromosomes). In some cases, the chromosome is missing in some cells but not others, a condition referred to as mosaicism or \"Turner mosaicism\".",
+        "condition_remarks": "Within all the people who go to their doctor with turner syndrome, 27% report having groin mass, 27% report having lack of growth, and 27% report having blood in stool. The symptoms that are highly suggestive of turner syndrome are groin mass, blood in stool, lack of growth, diminished hearing, emotional symptoms, elbow weakness, back weakness, and pus in sputum, although you may still have turner syndrome without those symptoms.",
+        "symptoms": {
+            "groin-mass": {
+                "slug": "groin-mass",
+                "probability": 27
+            },
+            "leg-pain": {
+                "slug": "leg-pain",
+                "probability": 27
+            },
+            "hip-pain": {
+                "slug": "hip-pain",
+                "probability": 27
+            },
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 27
+            },
+            "blood-in-stool": {
+                "slug": "blood-in-stool",
+                "probability": 27
+            },
+            "lack-of-growth": {
+                "slug": "lack-of-growth",
+                "probability": 27
+            },
+            "diminished-hearing": {
+                "slug": "diminished-hearing",
+                "probability": 27
+            },
+            "depression": {
+                "slug": "depression",
+                "probability": 27
+            },
+            "emotional-symptoms": {
+                "slug": "emotional-symptoms",
+                "probability": 2
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 2
+            },
+            "back-weakness": {
+                "slug": "back-weakness",
+                "probability": 2
+            },
+            "pus-in-sputum": {
+                "slug": "pus-in-sputum",
+                "probability": 2
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -88632,9 +91258,58 @@
     "typhoid-fever": {
         "condition_name": "Typhoid fever",
         "condition_slug": "typhoid-fever",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Typhoid fever, also known simply as typhoid, is a common worldwide bacterial disease transmitted by the ingestion of food or water contaminated with the feces of an infected person, which contain the bacterium Salmonella enterica enterica, serovar Typhi.",
+        "condition_remarks": "Within all the people who go to their doctor with typhoid fever, 100% report having fever, 32% report having preoccupation with sex, and 32% report having wrist cramps or spasms. The symptoms that are highly suggestive of typhoid fever are fever, shoulder cramps or spasms, joint stiffness or tightness, and knee lump or mass, although you may still have typhoid fever without those symptoms.",
+        "symptoms": {
+            "fever": {
+                "slug": "fever",
+                "probability": 100
+            },
+            "shoulder-cramps-or-spasms": {
+                "slug": "shoulder-cramps-or-spasms",
+                "probability": 32
+            },
+            "excessive-anger": {
+                "slug": "excessive-anger",
+                "probability": 32
+            },
+            "ankle-pain": {
+                "slug": "ankle-pain",
+                "probability": 32
+            },
+            "wrist-pain": {
+                "slug": "wrist-pain",
+                "probability": 32
+            },
+            "pain-during-pregnancy": {
+                "slug": "pain-during-pregnancy",
+                "probability": 32
+            },
+            "facial-pain": {
+                "slug": "facial-pain",
+                "probability": 32
+            },
+            "joint-stiffness-or-tightness": {
+                "slug": "joint-stiffness-or-tightness",
+                "probability": 32
+            },
+            "pain-or-soreness-of-breast": {
+                "slug": "pain-or-soreness-of-breast",
+                "probability": 32
+            },
+            "knee-lump-or-mass": {
+                "slug": "knee-lump-or-mass",
+                "probability": 32
+            },
+            "pain-in-eye": {
+                "slug": "pain-in-eye",
+                "probability": 32
+            },
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 32
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -88715,9 +91390,58 @@
     "ulcerative-colitis": {
         "condition_name": "Ulcerative colitis",
         "condition_slug": "ulcerative-colitis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Ulcerative colitis (Colitis ulcerosa, UC) is a form of inflammatory bowel disease (IBD). Ulcerative colitis is a form of colitis, a disease of the colon (large intestine), that includes characteristic ulcers, or open sores. The main symptom of active disease is usually constant diarrhea mixed with blood, of gradual onset. IBD is often confused with irritable bowel syndrome (IBS), a troublesome but much less serious condition.",
+        "condition_remarks": "Within all the people who go to their doctor with ulcerative colitis, 65% report having diarrhea, 53% report having sharp abdominal pain, and 40% report having blood in stool. The symptoms that are highly suggestive of ulcerative colitis are blood in stool, melena, and discharge in stools, although you may still have ulcerative colitis without those symptoms.",
+        "symptoms": {
+            "diarrhea": {
+                "slug": "diarrhea",
+                "probability": 65
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 53
+            },
+            "blood-in-stool": {
+                "slug": "blood-in-stool",
+                "probability": 40
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 35
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 33
+            },
+            "burning-abdominal-pain": {
+                "slug": "burning-abdominal-pain",
+                "probability": 26
+            },
+            "rectal-bleeding": {
+                "slug": "rectal-bleeding",
+                "probability": 23
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 15
+            },
+            "melena": {
+                "slug": "melena",
+                "probability": 11
+            },
+            "decreased-appetite": {
+                "slug": "decreased-appetite",
+                "probability": 11
+            },
+            "swollen-lymph-nodes": {
+                "slug": "swollen-lymph-nodes",
+                "probability": 11
+            },
+            "discharge-in-stools": {
+                "slug": "discharge-in-stools",
+                "probability": 11
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -88798,9 +91522,58 @@
     "urethral-disorder": {
         "condition_name": "Urethral disorder",
         "condition_slug": "urethral-disorder",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "In anatomy, the urethra (from Greek \u03bf\u1f50\u03c1\u03ae\u03b8\u03c1\u03b1 - ourethra) is a tube that connects the urinary bladder to the genitals for the removal of fluids from the body. In males, the urethra travels through the penis, and carries semen as well as urine. In female placental mammals, the urethra is shorter and emerges above the vaginal opening.",
+        "condition_remarks": "Within all the people who go to their doctor with urethral disorder, 61% report having painful urination, 58% report having involuntary urination, and 55% report having retention of urine. The symptoms that are highly suggestive of urethral disorder are painful urination, involuntary urination, retention of urine, frequent urination, and symptoms of bladder, although you may still have urethral disorder without those symptoms.",
+        "symptoms": {
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 61
+            },
+            "involuntary-urination": {
+                "slug": "involuntary-urination",
+                "probability": 58
+            },
+            "retention-of-urine": {
+                "slug": "retention-of-urine",
+                "probability": 55
+            },
+            "frequent-urination": {
+                "slug": "frequent-urination",
+                "probability": 52
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 52
+            },
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 34
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 28
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 28
+            },
+            "blood-in-urine": {
+                "slug": "blood-in-urine",
+                "probability": 28
+            },
+            "symptoms-of-bladder": {
+                "slug": "symptoms-of-bladder",
+                "probability": 20
+            },
+            "side-pain": {
+                "slug": "side-pain",
+                "probability": 20
+            },
+            "abusing-alcohol": {
+                "slug": "abusing-alcohol",
+                "probability": 11
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -88881,9 +91654,58 @@
     "urethral-stricture": {
         "condition_name": "Urethral stricture",
         "condition_slug": "urethral-stricture",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A urethral stricture is a narrowing of the urethra caused by injury or disease such as urinary tract infections or other forms of urethritis.",
+        "condition_remarks": "Within all the people who go to their doctor with urethral stricture, 73% report having retention of urine, 36% report having painful urination, and 34% report having suprapubic pain. The symptoms that are highly suggestive of urethral stricture are retention of urine, involuntary urination, symptoms of bladder, symptoms of prostate, symptoms of the scrotum and testes, and penis redness, although you may still have urethral stricture without those symptoms.",
+        "symptoms": {
+            "retention-of-urine": {
+                "slug": "retention-of-urine",
+                "probability": 73
+            },
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 36
+            },
+            "frequent-urination": {
+                "slug": "frequent-urination",
+                "probability": 34
+            },
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 34
+            },
+            "involuntary-urination": {
+                "slug": "involuntary-urination",
+                "probability": 27
+            },
+            "blood-in-urine": {
+                "slug": "blood-in-urine",
+                "probability": 24
+            },
+            "symptoms-of-bladder": {
+                "slug": "symptoms-of-bladder",
+                "probability": 16
+            },
+            "symptoms-of-prostate": {
+                "slug": "symptoms-of-prostate",
+                "probability": 11
+            },
+            "symptoms-of-the-scrotum-and-testes": {
+                "slug": "symptoms-of-the-scrotum-and-testes",
+                "probability": 6
+            },
+            "excessive-urination-at-night": {
+                "slug": "excessive-urination-at-night",
+                "probability": 6
+            },
+            "penis-redness": {
+                "slug": "penis-redness",
+                "probability": 6
+            },
+            "swelling-of-scrotum": {
+                "slug": "swelling-of-scrotum",
+                "probability": 6
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -88964,9 +91786,58 @@
     "urethral-valves": {
         "condition_name": "Urethral valves",
         "condition_slug": "urethral-valves",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Urethral valves is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with urethral valves, 67% report having side pain, 53% report having sharp abdominal pain, and 42% report having lower abdominal pain. The symptoms that are highly suggestive of urethral valves are side pain, muscle swelling, low back weakness, and elbow weakness, although you may still have urethral valves without those symptoms.",
+        "symptoms": {
+            "side-pain": {
+                "slug": "side-pain",
+                "probability": 67
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 53
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 42
+            },
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 27
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 27
+            },
+            "constipation": {
+                "slug": "constipation",
+                "probability": 27
+            },
+            "blood-in-urine": {
+                "slug": "blood-in-urine",
+                "probability": 27
+            },
+            "skin-growth": {
+                "slug": "skin-growth",
+                "probability": 27
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 27
+            },
+            "muscle-swelling": {
+                "slug": "muscle-swelling",
+                "probability": 2
+            },
+            "low-back-weakness": {
+                "slug": "low-back-weakness",
+                "probability": 2
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 2
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -89047,9 +91918,58 @@
     "urethritis": {
         "condition_name": "Urethritis",
         "condition_slug": "urethritis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Urethritis is inflammation of the urethra. The most common symptom is painful or difficult urination.",
+        "condition_remarks": "Within all the people who go to their doctor with urethritis, 83% report having painful urination, 74% report having penile discharge, and 39% report having frequent urination. The symptoms that are highly suggestive of urethritis are painful urination, penile discharge, penis pain, and pain in testicles, although you may still have urethritis without those symptoms.",
+        "symptoms": {
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 83
+            },
+            "penile-discharge": {
+                "slug": "penile-discharge",
+                "probability": 74
+            },
+            "frequent-urination": {
+                "slug": "frequent-urination",
+                "probability": 39
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 37
+            },
+            "blood-in-urine": {
+                "slug": "blood-in-urine",
+                "probability": 34
+            },
+            "penis-pain": {
+                "slug": "penis-pain",
+                "probability": 32
+            },
+            "retention-of-urine": {
+                "slug": "retention-of-urine",
+                "probability": 30
+            },
+            "pain-in-testicles": {
+                "slug": "pain-in-testicles",
+                "probability": 27
+            },
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 27
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 12
+            },
+            "vaginal-itching": {
+                "slug": "vaginal-itching",
+                "probability": 12
+            },
+            "itching-of-skin": {
+                "slug": "itching-of-skin",
+                "probability": 12
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -89130,9 +92050,58 @@
     "urge-incontinence": {
         "condition_name": "Urge incontinence",
         "condition_slug": "urge-incontinence",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Urge incontinence is a form of urinary incontinence characterized by the involuntary loss of urine occurring for no apparent reason while feeling urinary urgency, a sudden need or urge to urinate.",
+        "condition_remarks": "Within all the people who go to their doctor with urge incontinence, 80% report having frequent urination, 58% report having involuntary urination, and 44% report having symptoms of bladder. The symptoms that are highly suggestive of urge incontinence are frequent urination, involuntary urination, symptoms of bladder, retention of urine, and excessive urination at night, although you may still have urge incontinence without those symptoms.",
+        "symptoms": {
+            "frequent-urination": {
+                "slug": "frequent-urination",
+                "probability": 80
+            },
+            "involuntary-urination": {
+                "slug": "involuntary-urination",
+                "probability": 58
+            },
+            "symptoms-of-bladder": {
+                "slug": "symptoms-of-bladder",
+                "probability": 44
+            },
+            "retention-of-urine": {
+                "slug": "retention-of-urine",
+                "probability": 37
+            },
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 37
+            },
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 28
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 25
+            },
+            "blood-in-urine": {
+                "slug": "blood-in-urine",
+                "probability": 25
+            },
+            "excessive-urination-at-night": {
+                "slug": "excessive-urination-at-night",
+                "probability": 22
+            },
+            "constipation": {
+                "slug": "constipation",
+                "probability": 12
+            },
+            "vaginal-itching": {
+                "slug": "vaginal-itching",
+                "probability": 9
+            },
+            "symptoms-of-prostate": {
+                "slug": "symptoms-of-prostate",
+                "probability": 9
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -89213,9 +92182,58 @@
     "urinary-tract-infection": {
         "condition_name": "Urinary tract infection",
         "condition_slug": "urinary-tract-infection",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A urinary tract infection (UTI) (also known as acute cystitis or bladder infection) is an infection that affects part of the urinary tract. When it affects the lower urinary tract it is known as a simple cystitis (a bladder infection) and when it affects the upper urinary tract it is known as pyelonephritis (a kidney infection). Symptoms from a lower urinary tract include painful urination and either frequent urination or urge to urinate (or both), while those of pyelonephritis include fever and flank pain in addition to the symptoms of a lower UTI. In the elderly and the very young, symptoms may be vague or non specific. The main causal agent of both types is Escherichia coli, however other bacteria, viruses or fungi may rarely be the cause.",
+        "condition_remarks": "Within all the people who go to their doctor with urinary tract infection, 65% report having painful urination, 60% report having suprapubic pain, and 60% report having sharp abdominal pain. The symptoms that are highly suggestive of urinary tract infection are painful urination, suprapubic pain, frequent urination, and blood in urine, although you may still have urinary tract infection without those symptoms.",
+        "symptoms": {
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 65
+            },
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 60
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 60
+            },
+            "frequent-urination": {
+                "slug": "frequent-urination",
+                "probability": 46
+            },
+            "fever": {
+                "slug": "fever",
+                "probability": 42
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 40
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 36
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 35
+            },
+            "blood-in-urine": {
+                "slug": "blood-in-urine",
+                "probability": 33
+            },
+            "side-pain": {
+                "slug": "side-pain",
+                "probability": 31
+            },
+            "retention-of-urine": {
+                "slug": "retention-of-urine",
+                "probability": 26
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 25
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -89296,9 +92314,58 @@
     "urinary-tract-obstruction": {
         "condition_name": "Urinary tract obstruction",
         "condition_slug": "urinary-tract-obstruction",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Urinary retention, also known as ischuria, is a lack of ability to urinate. It is a common complication of benign prostatic hyperplasia (BPH), though it can also be caused by:",
+        "condition_remarks": "Within all the people who go to their doctor with urinary tract obstruction, 64% report having retention of urine, 45% report having blood in urine, and 42% report having side pain. The symptoms that are highly suggestive of urinary tract obstruction are retention of urine, blood in urine, symptoms of prostate, symptoms of bladder, and excessive urination at night, although you may still have urinary tract obstruction without those symptoms.",
+        "symptoms": {
+            "retention-of-urine": {
+                "slug": "retention-of-urine",
+                "probability": 64
+            },
+            "blood-in-urine": {
+                "slug": "blood-in-urine",
+                "probability": 45
+            },
+            "side-pain": {
+                "slug": "side-pain",
+                "probability": 42
+            },
+            "frequent-urination": {
+                "slug": "frequent-urination",
+                "probability": 35
+            },
+            "symptoms-of-prostate": {
+                "slug": "symptoms-of-prostate",
+                "probability": 33
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 31
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 25
+            },
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 22
+            },
+            "symptoms-of-bladder": {
+                "slug": "symptoms-of-bladder",
+                "probability": 20
+            },
+            "excessive-urination-at-night": {
+                "slug": "excessive-urination-at-night",
+                "probability": 20
+            },
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 17
+            },
+            "involuntary-urination": {
+                "slug": "involuntary-urination",
+                "probability": 17
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -89379,9 +92446,50 @@
     "uterine-atony": {
         "condition_name": "Uterine atony",
         "condition_slug": "uterine-atony",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Uterine atony is a loss of tone in the uterine musculature. Normally, contraction of the uterine muscle compresses the vessels and reduces flow. This increases the likelihood of coagulation and prevents bleeds. Thus, lack of uterine muscle contraction can cause an acute hemorrhage. Clinically, 75-80% of postpartum hemorrhages are due to uterine atony.",
+        "condition_remarks": "Within all the people who go to their doctor with uterine atony, 88% report having spotting or bleeding during pregnancy, 59% report having sharp abdominal pain, and 53% report having pain during pregnancy. The symptoms that are highly suggestive of uterine atony are spotting or bleeding during pregnancy, pain during pregnancy, intermenstrual bleeding, and back cramps or spasms, although you may still have uterine atony without those symptoms.",
+        "symptoms": {
+            "spotting-or-bleeding-during-pregnancy": {
+                "slug": "spotting-or-bleeding-during-pregnancy",
+                "probability": 88
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 59
+            },
+            "pain-during-pregnancy": {
+                "slug": "pain-during-pregnancy",
+                "probability": 53
+            },
+            "intermenstrual-bleeding": {
+                "slug": "intermenstrual-bleeding",
+                "probability": 34
+            },
+            "problems-during-pregnancy": {
+                "slug": "problems-during-pregnancy",
+                "probability": 28
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 24
+            },
+            "uterine-contractions": {
+                "slug": "uterine-contractions",
+                "probability": 16
+            },
+            "blood-in-urine": {
+                "slug": "blood-in-urine",
+                "probability": 11
+            },
+            "infertility": {
+                "slug": "infertility",
+                "probability": 6
+            },
+            "back-cramps-or-spasms": {
+                "slug": "back-cramps-or-spasms",
+                "probability": 6
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -89462,9 +92570,58 @@
     "uterine-cancer": {
         "condition_name": "Uterine cancer",
         "condition_slug": "uterine-cancer",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "The term uterine cancer may refer to any of several different types of cancer which occur in the uterus, namely:",
+        "condition_remarks": "Within all the people who go to their doctor with uterine cancer, 19% report having vaginal bleeding after menopause, 10% report having pelvic pain, and 4% report having tongue lesions. The symptoms that are highly suggestive of uterine cancer are vaginal bleeding after menopause, although you may still have uterine cancer without those symptoms.",
+        "symptoms": {
+            "vaginal-bleeding-after-menopause": {
+                "slug": "vaginal-bleeding-after-menopause",
+                "probability": 19
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 10
+            },
+            "hot-flashes": {
+                "slug": "hot-flashes",
+                "probability": 4
+            },
+            "focal-weakness": {
+                "slug": "focal-weakness",
+                "probability": 4
+            },
+            "heavy-menstrual-flow": {
+                "slug": "heavy-menstrual-flow",
+                "probability": 4
+            },
+            "cramps-and-spasms": {
+                "slug": "cramps-and-spasms",
+                "probability": 4
+            },
+            "tongue-lesions": {
+                "slug": "tongue-lesions",
+                "probability": 4
+            },
+            "muscle-pain": {
+                "slug": "muscle-pain",
+                "probability": 4
+            },
+            "intermenstrual-bleeding": {
+                "slug": "intermenstrual-bleeding",
+                "probability": 4
+            },
+            "gum-pain": {
+                "slug": "gum-pain",
+                "probability": 4
+            },
+            "unpredictable-menstruation": {
+                "slug": "unpredictable-menstruation",
+                "probability": 4
+            },
+            "groin-mass": {
+                "slug": "groin-mass",
+                "probability": 4
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -89545,9 +92702,58 @@
     "uterine-fibroids": {
         "condition_name": "Uterine fibroids",
         "condition_slug": "uterine-fibroids",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A uterine fibroid is a leiomyoma (benign (non-cancerous) tumor from smooth muscle tissue) that originates from the smooth muscle layer (myometrium) of the uterus. Fibroids are often multiple and garner the designation of diffuse uterine leiomyomatosis if they are randomly located and many in numbers. There is a malignant form of a fibroid and fibroids can rarely (0.1-0.5%), undergo malignant degeneration into leiomyosarcoma. Additionally there are rare forms of fibroids where the lesions are capable of metastasising without malignant transformation and this process is called benign metastasising leiomyoma.",
+        "condition_remarks": "Within all the people who go to their doctor with uterine fibroids, 49% report having sharp abdominal pain, 42% report having pelvic pain, and 37% report having heavy menstrual flow. The symptoms that are highly suggestive of uterine fibroids are pelvic pain, heavy menstrual flow, unpredictable menstruation, painful menstruation, intermenstrual bleeding, and long menstrual periods, although you may still have uterine fibroids without those symptoms.",
+        "symptoms": {
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 49
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 42
+            },
+            "heavy-menstrual-flow": {
+                "slug": "heavy-menstrual-flow",
+                "probability": 37
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 22
+            },
+            "unpredictable-menstruation": {
+                "slug": "unpredictable-menstruation",
+                "probability": 20
+            },
+            "painful-menstruation": {
+                "slug": "painful-menstruation",
+                "probability": 12
+            },
+            "intermenstrual-bleeding": {
+                "slug": "intermenstrual-bleeding",
+                "probability": 11
+            },
+            "long-menstrual-periods": {
+                "slug": "long-menstrual-periods",
+                "probability": 11
+            },
+            "infertility": {
+                "slug": "infertility",
+                "probability": 8
+            },
+            "vaginal-discharge": {
+                "slug": "vaginal-discharge",
+                "probability": 8
+            },
+            "involuntary-urination": {
+                "slug": "involuntary-urination",
+                "probability": 8
+            },
+            "cramps-and-spasms": {
+                "slug": "cramps-and-spasms",
+                "probability": 6
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -89628,9 +92834,58 @@
     "uveitis": {
         "condition_name": "Uveitis",
         "condition_slug": "uveitis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Uveitis is, broadly, inflammation of the uvea. The uvea consists of the middle, pigmented, vascular structures of the eye and includes the iris, ciliary body, and choroid. Uveitis requires an urgent referral and thorough examination by an ophthalmologist or optometrist\u2014and urgent treatment to control the inflammation.",
+        "condition_remarks": "Within all the people who go to their doctor with uveitis, 74% report having diminished vision, 57% report having symptoms of eye, and 57% report having upper abdominal pain. The symptoms that are highly suggestive of uveitis are diminished vision, symptoms of eye, upper abdominal pain, eye redness, elbow cramps or spasms, wrist weakness, nailbiting, hip stiffness or tightness, vulvar sore, elbow weakness, cross-eyed, and itchy eyelid, although you may still have uveitis without those symptoms.",
+        "symptoms": {
+            "diminished-vision": {
+                "slug": "diminished-vision",
+                "probability": 74
+            },
+            "symptoms-of-eye": {
+                "slug": "symptoms-of-eye",
+                "probability": 57
+            },
+            "upper-abdominal-pain": {
+                "slug": "upper-abdominal-pain",
+                "probability": 57
+            },
+            "eye-redness": {
+                "slug": "eye-redness",
+                "probability": 57
+            },
+            "elbow-cramps-or-spasms": {
+                "slug": "elbow-cramps-or-spasms",
+                "probability": 5
+            },
+            "wrist-weakness": {
+                "slug": "wrist-weakness",
+                "probability": 5
+            },
+            "nailbiting": {
+                "slug": "nailbiting",
+                "probability": 5
+            },
+            "hip-stiffness-or-tightness": {
+                "slug": "hip-stiffness-or-tightness",
+                "probability": 5
+            },
+            "vulvar-sore": {
+                "slug": "vulvar-sore",
+                "probability": 5
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 5
+            },
+            "cross-eyed": {
+                "slug": "cross-eyed",
+                "probability": 5
+            },
+            "itchy-eyelid": {
+                "slug": "itchy-eyelid",
+                "probability": 5
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -89711,9 +92966,58 @@
     "vacterl-syndrome": {
         "condition_name": "VACTERL syndrome",
         "condition_slug": "vacterl-syndrome",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "VACTERL syndrome is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with vacterl syndrome, 49% report having regurgitation, 49% report having suprapubic pain, and 49% report having lower abdominal pain. The symptoms that are highly suggestive of vacterl syndrome are lower abdominal pain, regurgitation, suprapubic pain, excessive growth, cross-eyed, elbow weakness, wrist weakness, emotional symptoms, feeling hot and cold, bowlegged or knock-kneed, elbow cramps or spasms, and nailbiting, although you may still have vacterl syndrome without those symptoms.",
+        "symptoms": {
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 49
+            },
+            "regurgitation": {
+                "slug": "regurgitation",
+                "probability": 49
+            },
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 49
+            },
+            "excessive-growth": {
+                "slug": "excessive-growth",
+                "probability": 4
+            },
+            "cross-eyed": {
+                "slug": "cross-eyed",
+                "probability": 4
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 4
+            },
+            "wrist-weakness": {
+                "slug": "wrist-weakness",
+                "probability": 4
+            },
+            "emotional-symptoms": {
+                "slug": "emotional-symptoms",
+                "probability": 4
+            },
+            "feeling-hot-and-cold": {
+                "slug": "feeling-hot-and-cold",
+                "probability": 4
+            },
+            "bowlegged-or-knock-kneed": {
+                "slug": "bowlegged-or-knock-kneed",
+                "probability": 4
+            },
+            "elbow-cramps-or-spasms": {
+                "slug": "elbow-cramps-or-spasms",
+                "probability": 4
+            },
+            "nailbiting": {
+                "slug": "nailbiting",
+                "probability": 4
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -89794,9 +93098,58 @@
     "vaginal-cyst": {
         "condition_name": "Vaginal cyst",
         "condition_slug": "vaginal-cyst",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Vaginal cyst is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with vaginal cyst, 56% report having sharp abdominal pain, 36% report having spotting or bleeding during pregnancy, and 25% report having pelvic pain. The symptoms that are highly suggestive of vaginal cyst are spotting or bleeding during pregnancy, vaginal pain, cramps and spasms, intermenstrual bleeding, blood clots during menstrual periods, and heavy menstrual flow, although you may still have vaginal cyst without those symptoms.",
+        "symptoms": {
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 56
+            },
+            "spotting-or-bleeding-during-pregnancy": {
+                "slug": "spotting-or-bleeding-during-pregnancy",
+                "probability": 36
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 25
+            },
+            "vaginal-pain": {
+                "slug": "vaginal-pain",
+                "probability": 24
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 23
+            },
+            "vaginal-discharge": {
+                "slug": "vaginal-discharge",
+                "probability": 22
+            },
+            "cramps-and-spasms": {
+                "slug": "cramps-and-spasms",
+                "probability": 20
+            },
+            "intermenstrual-bleeding": {
+                "slug": "intermenstrual-bleeding",
+                "probability": 19
+            },
+            "blood-clots-during-menstrual-periods": {
+                "slug": "blood-clots-during-menstrual-periods",
+                "probability": 17
+            },
+            "pain-during-pregnancy": {
+                "slug": "pain-during-pregnancy",
+                "probability": 15
+            },
+            "heavy-menstrual-flow": {
+                "slug": "heavy-menstrual-flow",
+                "probability": 14
+            },
+            "problems-during-pregnancy": {
+                "slug": "problems-during-pregnancy",
+                "probability": 11
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -89877,9 +93230,58 @@
     "vaginal-yeast-infection": {
         "condition_name": "Vaginal yeast infection",
         "condition_slug": "vaginal-yeast-infection",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Candidiasis or thrush is a fungal infection (mycosis) of any of the Candida species (all yeasts), of which Candida albicans is the most common. Also commonly referred to as a yeast infection, candidiasis is also technically known as candidosis, moniliasis, and oidiomycosis.",
+        "condition_remarks": "Within all the people who go to their doctor with vaginal yeast infection, 79% report having vaginal itching, 77% report having vaginal discharge, and 41% report having painful urination. The symptoms that are highly suggestive of vaginal yeast infection are vaginal itching, vaginal discharge, vaginal pain, vaginal redness, and vulvar irritation, although you may still have vaginal yeast infection without those symptoms.",
+        "symptoms": {
+            "vaginal-itching": {
+                "slug": "vaginal-itching",
+                "probability": 79
+            },
+            "vaginal-discharge": {
+                "slug": "vaginal-discharge",
+                "probability": 77
+            },
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 41
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 32
+            },
+            "vaginal-pain": {
+                "slug": "vaginal-pain",
+                "probability": 24
+            },
+            "vaginal-redness": {
+                "slug": "vaginal-redness",
+                "probability": 23
+            },
+            "itching-of-skin": {
+                "slug": "itching-of-skin",
+                "probability": 20
+            },
+            "problems-during-pregnancy": {
+                "slug": "problems-during-pregnancy",
+                "probability": 19
+            },
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 19
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 19
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 17
+            },
+            "vulvar-irritation": {
+                "slug": "vulvar-irritation",
+                "probability": 14
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -89960,9 +93362,58 @@
     "vaginismus": {
         "condition_name": "Vaginismus",
         "condition_slug": "vaginismus",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Vaginismus, sometimes anglicized vaginism, is the condition that affects a woman's ability to engage in any form of vaginal penetration, including sexual intercourse, insertion of tampons and/or menstrual cups, and the penetration involved in gynecological examinations. This is the result of a reflex of the pubococcygeus muscle, which is sometimes referred to as the \"PC muscle\". The reflex causes the muscles in the vagina to tense suddenly, which makes any kind of vaginal penetration\u2014including sexual intercourse\u2014painful or impossible.",
+        "condition_remarks": "Within all the people who go to their doctor with vaginismus, 84% report having pain during intercourse, 52% report having pelvic pain, and 34% report having vaginal pain. The symptoms that are highly suggestive of vaginismus are pain during intercourse, pelvic pain, vaginal pain, vaginal dryness, painful menstruation, hot flashes, and heavy menstrual flow, although you may still have vaginismus without those symptoms.",
+        "symptoms": {
+            "pain-during-intercourse": {
+                "slug": "pain-during-intercourse",
+                "probability": 84
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 52
+            },
+            "vaginal-pain": {
+                "slug": "vaginal-pain",
+                "probability": 34
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 29
+            },
+            "frequent-urination": {
+                "slug": "frequent-urination",
+                "probability": 29
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 23
+            },
+            "vaginal-dryness": {
+                "slug": "vaginal-dryness",
+                "probability": 17
+            },
+            "vaginal-discharge": {
+                "slug": "vaginal-discharge",
+                "probability": 17
+            },
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 17
+            },
+            "painful-menstruation": {
+                "slug": "painful-menstruation",
+                "probability": 17
+            },
+            "hot-flashes": {
+                "slug": "hot-flashes",
+                "probability": 17
+            },
+            "heavy-menstrual-flow": {
+                "slug": "heavy-menstrual-flow",
+                "probability": 17
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -90043,9 +93494,58 @@
     "vaginitis": {
         "condition_name": "Vaginitis",
         "condition_slug": "vaginitis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Vaginitis is an inflammation of the vagina. It can result in discharge, itching and pain, and is often associated with an irritation or infection of the vulva. It is usually due to infection. The three main kinds of vaginitis are bacterial vaginosis (BV), vaginal candidiasis, and trichomoniasis. A woman may have any combination of vaginal infections at one time. The symptoms that arise vary with the infection, although there are general symptoms that all vaginitis infections have and infected women may also be asymptomatic. Testing for vaginal infections is not a part of routine pelvic exams; therefore, women should neither assume their health care providers will know of the infection, nor that they will provide appropriate treatment without their input.",
+        "condition_remarks": "Within all the people who go to their doctor with vaginitis, 78% report having vaginal discharge, 59% report having vaginal itching, and 49% report having sharp abdominal pain. The symptoms that are highly suggestive of vaginitis are vaginal discharge, vaginal itching, vaginal pain, vaginal redness, vulvar irritation, and pain during intercourse, although you may still have vaginitis without those symptoms.",
+        "symptoms": {
+            "vaginal-discharge": {
+                "slug": "vaginal-discharge",
+                "probability": 78
+            },
+            "vaginal-itching": {
+                "slug": "vaginal-itching",
+                "probability": 59
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 49
+            },
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 40
+            },
+            "vaginal-pain": {
+                "slug": "vaginal-pain",
+                "probability": 29
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 26
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 23
+            },
+            "vaginal-redness": {
+                "slug": "vaginal-redness",
+                "probability": 19
+            },
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 16
+            },
+            "pain-during-pregnancy": {
+                "slug": "pain-during-pregnancy",
+                "probability": 12
+            },
+            "vulvar-irritation": {
+                "slug": "vulvar-irritation",
+                "probability": 10
+            },
+            "pain-during-intercourse": {
+                "slug": "pain-during-intercourse",
+                "probability": 10
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -90126,9 +93626,58 @@
     "valley-fever": {
         "condition_name": "Valley fever",
         "condition_slug": "valley-fever",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Coccidioidomycosis (/k\u0252k\u02ccs\u026adi\u0254\u026ado\u028ama\u026a\u02c8ko\u028as\u026as/, kok-sid-oy-doh-my-KOH-sis), commonly known as \"Valley fever\", as well as \"California fever\", \"Desert rheumatism\", and \"San Joaquin Valley fever\") is a fungal disease caused by Coccidioides immitis or C. posadasii. It is endemic in certain parts of Arizona, California, Nevada, New Mexico, Texas, Utah and northern Mexico.",
+        "condition_remarks": "Within all the people who go to their doctor with valley fever, 86% report having fever, 77% report having shortness of breath, and 60% report having joint pain. The symptoms that are highly suggestive of valley fever are joint pain, fatigue, chills, hurts to breath, hand or finger pain, shoulder swelling, hip stiffness or tightness, and vulvar sore, although you may still have valley fever without those symptoms.",
+        "symptoms": {
+            "fever": {
+                "slug": "fever",
+                "probability": 86
+            },
+            "shortness-of-breath": {
+                "slug": "shortness-of-breath",
+                "probability": 77
+            },
+            "joint-pain": {
+                "slug": "joint-pain",
+                "probability": 60
+            },
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 60
+            },
+            "chills": {
+                "slug": "chills",
+                "probability": 60
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 60
+            },
+            "ache-all-over": {
+                "slug": "ache-all-over",
+                "probability": 60
+            },
+            "hurts-to-breath": {
+                "slug": "hurts-to-breath",
+                "probability": 60
+            },
+            "hand-or-finger-pain": {
+                "slug": "hand-or-finger-pain",
+                "probability": 60
+            },
+            "shoulder-swelling": {
+                "slug": "shoulder-swelling",
+                "probability": 6
+            },
+            "hip-stiffness-or-tightness": {
+                "slug": "hip-stiffness-or-tightness",
+                "probability": 6
+            },
+            "vulvar-sore": {
+                "slug": "vulvar-sore",
+                "probability": 6
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -90209,9 +93758,58 @@
     "varicocele-of-the-testicles": {
         "condition_name": "Varicocele of the testicles",
         "condition_slug": "varicocele-of-the-testicles",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Varicocele /\u02c8v\u00e6r\u0268k\u0275si\u02d0l/ is an abnormal enlargement of the pampiniform venous plexus in the scrotum. This plexus of veins drains the testicles. The testicular blood vessels originate in the abdomen and course down through the inguinal canal as part of the spermatic cord on their way to the testis. Upward flow of blood in the veins is ensured by small one-way valves that prevent backflow. Defective valves, or compression of the vein by a nearby structure, can cause dilatation of the testicular veins near the testis, leading to the formation of a varicocele.",
+        "condition_remarks": "Within all the people who go to their doctor with varicocele of the testicles, 72% report having pain in testicles, 71% report having mass in scrotum, and 41% report having symptoms of the scrotum and testes. The symptoms that are highly suggestive of varicocele of the testicles are pain in testicles, mass in scrotum, symptoms of the scrotum and testes, groin pain, swelling of scrotum, infertility, impotence, and penis pain, although you may still have varicocele of the testicles without those symptoms.",
+        "symptoms": {
+            "pain-in-testicles": {
+                "slug": "pain-in-testicles",
+                "probability": 72
+            },
+            "mass-in-scrotum": {
+                "slug": "mass-in-scrotum",
+                "probability": 71
+            },
+            "symptoms-of-the-scrotum-and-testes": {
+                "slug": "symptoms-of-the-scrotum-and-testes",
+                "probability": 41
+            },
+            "groin-pain": {
+                "slug": "groin-pain",
+                "probability": 34
+            },
+            "swelling-of-scrotum": {
+                "slug": "swelling-of-scrotum",
+                "probability": 31
+            },
+            "infertility": {
+                "slug": "infertility",
+                "probability": 25
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 22
+            },
+            "involuntary-urination": {
+                "slug": "involuntary-urination",
+                "probability": 18
+            },
+            "impotence": {
+                "slug": "impotence",
+                "probability": 18
+            },
+            "skin-growth": {
+                "slug": "skin-growth",
+                "probability": 14
+            },
+            "penis-pain": {
+                "slug": "penis-pain",
+                "probability": 10
+            },
+            "pain-of-the-anus": {
+                "slug": "pain-of-the-anus",
+                "probability": 10
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -90292,9 +93890,46 @@
     "varicose-veins": {
         "condition_name": "Varicose veins",
         "condition_slug": "varicose-veins",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Vericose veins are veins that have become enlarged and tortuous. The term commonly refers to the veins on the leg, although varicose veins can occur elsewhere. Veins have leaflet valves to prevent blood from flowing backwards (retrograde flow or reflux). Leg muscles pump the veins to return blood to the heart (the calf muscle pump mechanism), against the effects of gravity. When veins become varicose, the leaflets of the valves no longer meet properly, and the valves do not work (valvular incompetence). This allows blood to flow backwards and they enlarge even more. Varicose veins are most common in the superficial veins of the legs, which are subject to high pressure when standing. Besides being a cosmetic problem, varicose veins can be painful, especially when standing. Severe long-standing varicose veins can lead to leg swelling, venous eczema, skin thickening (lipodermatosclerosis) and ulceration. Life-threatening complications are uncommon.",
+        "condition_remarks": "Within all the people who go to their doctor with varicose veins, 65% report having skin lesion, 50% report having leg pain, and 26% report having peripheral edema. The symptoms that are highly suggestive of varicose veins are skin lesion and lymphedema, although you may still have varicose veins without those symptoms.",
+        "symptoms": {
+            "skin-lesion": {
+                "slug": "skin-lesion",
+                "probability": 65
+            },
+            "leg-pain": {
+                "slug": "leg-pain",
+                "probability": 50
+            },
+            "peripheral-edema": {
+                "slug": "peripheral-edema",
+                "probability": 26
+            },
+            "ache-all-over": {
+                "slug": "ache-all-over",
+                "probability": 24
+            },
+            "lymphedema": {
+                "slug": "lymphedema",
+                "probability": 22
+            },
+            "leg-swelling": {
+                "slug": "leg-swelling",
+                "probability": 20
+            },
+            "leg-cramps-or-spasms": {
+                "slug": "leg-cramps-or-spasms",
+                "probability": 6
+            },
+            "skin-on-leg-or-foot-looks-infected": {
+                "slug": "skin-on-leg-or-foot-looks-infected",
+                "probability": 6
+            },
+            "leg-lump-or-mass": {
+                "slug": "leg-lump-or-mass",
+                "probability": 5
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -90375,9 +94010,58 @@
     "vasculitis": {
         "condition_name": "Vasculitis",
         "condition_slug": "vasculitis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Vasculitis (plural: vasculitides) is a group of disorders that destroy blood vessels by inflammation. Both arteries and veins are affected. Lymphangitis is sometimes considered a type of vasculitis. Vasculitis is primarily due to leukocyte migration and resultant damage.",
+        "condition_remarks": "Within all the people who go to their doctor with vasculitis, 46% report having skin rash, 38% report having skin lesion, and 35% report having headache. The symptoms that are highly suggestive of vasculitis are swollen tongue and leg stiffness or tightness, although you may still have vasculitis without those symptoms.",
+        "symptoms": {
+            "skin-rash": {
+                "slug": "skin-rash",
+                "probability": 46
+            },
+            "skin-lesion": {
+                "slug": "skin-lesion",
+                "probability": 38
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 35
+            },
+            "leg-pain": {
+                "slug": "leg-pain",
+                "probability": 30
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 25
+            },
+            "lymphedema": {
+                "slug": "lymphedema",
+                "probability": 9
+            },
+            "foot-or-toe-swelling": {
+                "slug": "foot-or-toe-swelling",
+                "probability": 6
+            },
+            "plugged-feeling-in-ear": {
+                "slug": "plugged-feeling-in-ear",
+                "probability": 6
+            },
+            "skin-irritation": {
+                "slug": "skin-irritation",
+                "probability": 6
+            },
+            "swollen-tongue": {
+                "slug": "swollen-tongue",
+                "probability": 3
+            },
+            "leg-lump-or-mass": {
+                "slug": "leg-lump-or-mass",
+                "probability": 3
+            },
+            "leg-stiffness-or-tightness": {
+                "slug": "leg-stiffness-or-tightness",
+                "probability": 3
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -90458,9 +94142,58 @@
     "venous-insufficiency": {
         "condition_name": "Venous insufficiency",
         "condition_slug": "venous-insufficiency",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Venous insufficiency can refer to:",
+        "condition_remarks": "Within all the people who go to their doctor with venous insufficiency, 63% report having skin lesion, 34% report having leg swelling, and 34% report having peripheral edema. The symptoms that are highly suggestive of venous insufficiency are skin lesion and leg swelling, although you may still have venous insufficiency without those symptoms.",
+        "symptoms": {
+            "skin-lesion": {
+                "slug": "skin-lesion",
+                "probability": 63
+            },
+            "leg-swelling": {
+                "slug": "leg-swelling",
+                "probability": 34
+            },
+            "leg-pain": {
+                "slug": "leg-pain",
+                "probability": 34
+            },
+            "peripheral-edema": {
+                "slug": "peripheral-edema",
+                "probability": 34
+            },
+            "abnormal-appearing-skin": {
+                "slug": "abnormal-appearing-skin",
+                "probability": 17
+            },
+            "leg-cramps-or-spasms": {
+                "slug": "leg-cramps-or-spasms",
+                "probability": 7
+            },
+            "fluid-retention": {
+                "slug": "fluid-retention",
+                "probability": 6
+            },
+            "lymphedema": {
+                "slug": "lymphedema",
+                "probability": 5
+            },
+            "skin-on-leg-or-foot-looks-infected": {
+                "slug": "skin-on-leg-or-foot-looks-infected",
+                "probability": 4
+            },
+            "ankle-swelling": {
+                "slug": "ankle-swelling",
+                "probability": 4
+            },
+            "poor-circulation": {
+                "slug": "poor-circulation",
+                "probability": 1
+            },
+            "burning-chest-pain": {
+                "slug": "burning-chest-pain",
+                "probability": 1
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -90541,9 +94274,58 @@
     "vertebrobasilar-insufficiency": {
         "condition_name": "Vertebrobasilar insufficiency",
         "condition_slug": "vertebrobasilar-insufficiency",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Vertebrobasilar insufficiency (VBI), or vertebral basilar ischemia (also called Beauty parlour syndrome (BPS)), refers to a temporary set of symptoms due to decreased blood flow in the posterior circulation of the brain. The posterior circulation supplies blood to the medulla, cerebellum, pons, midbrain, thalamus, and occipital cortex (responsible for vision). Therefore, the symptoms due to VBI vary according to which portions of the brain experience significantly decreased blood flow (see image of brain ). In the United States, 25% of strokes and transient ischemic attacks occur in the vertebrobasilar distribution. These must be separated from strokes arising from the anterior circulation, which involves the carotid arteries.",
+        "condition_remarks": "Within all the people who go to their doctor with vertebrobasilar insufficiency, 66% report having dizziness, 52% report having problems with movement, and 52% report having weakness. The symptoms that are highly suggestive of vertebrobasilar insufficiency are problems with movement, sweating, and foot or toe weakness, although you may still have vertebrobasilar insufficiency without those symptoms.",
+        "symptoms": {
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 66
+            },
+            "problems-with-movement": {
+                "slug": "problems-with-movement",
+                "probability": 52
+            },
+            "weakness": {
+                "slug": "weakness",
+                "probability": 52
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 52
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 41
+            },
+            "leg-pain": {
+                "slug": "leg-pain",
+                "probability": 41
+            },
+            "arm-pain": {
+                "slug": "arm-pain",
+                "probability": 26
+            },
+            "sweating": {
+                "slug": "sweating",
+                "probability": 26
+            },
+            "foot-or-toe-weakness": {
+                "slug": "foot-or-toe-weakness",
+                "probability": 26
+            },
+            "paresthesia": {
+                "slug": "paresthesia",
+                "probability": 26
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 26
+            },
+            "sharp-chest-pain": {
+                "slug": "sharp-chest-pain",
+                "probability": 26
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -90624,9 +94406,42 @@
     "vesicoureteral-reflux": {
         "condition_name": "Vesicoureteral reflux",
         "condition_slug": "vesicoureteral-reflux",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Vesicoureteral reflux (VUR) is an abnormal movement of urine from the bladder into ureters or kidneys. Urine normally travels from the kidneys via the ureters to the bladder. In vesicoureteral reflux the direction of urine flow is reversed (retrograde).",
+        "condition_remarks": "Within all the people who go to their doctor with vesicoureteral reflux, 61% report having suprapubic pain, 47% report having fever, and 22% report having blood in urine. The symptoms that are highly suggestive of vesicoureteral reflux are suprapubic pain and symptoms of the kidneys, although you may still have vesicoureteral reflux without those symptoms.",
+        "symptoms": {
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 61
+            },
+            "fever": {
+                "slug": "fever",
+                "probability": 47
+            },
+            "blood-in-urine": {
+                "slug": "blood-in-urine",
+                "probability": 22
+            },
+            "constipation": {
+                "slug": "constipation",
+                "probability": 22
+            },
+            "symptoms-of-the-kidneys": {
+                "slug": "symptoms-of-the-kidneys",
+                "probability": 12
+            },
+            "involuntary-urination": {
+                "slug": "involuntary-urination",
+                "probability": 12
+            },
+            "fluid-in-ear": {
+                "slug": "fluid-in-ear",
+                "probability": 12
+            },
+            "regurgitation": {
+                "slug": "regurgitation",
+                "probability": 12
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -90707,9 +94522,58 @@
     "viral-exanthem": {
         "condition_name": "Viral exanthem",
         "condition_slug": "viral-exanthem",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "An exanthem (from Greek \"exanthema\", a breaking out) is a widespread rash usually occurring in children. Exanthems can be caused by toxins or drugs, microorganisms, or can result from autoimmune disease.",
+        "condition_remarks": "Within all the people who go to their doctor with viral exanthem, 97% report having skin rash, 79% report having fever, and 40% report having cough. The symptoms that are highly suggestive of viral exanthem are skin rash and lip sore, although you may still have viral exanthem without those symptoms.",
+        "symptoms": {
+            "skin-rash": {
+                "slug": "skin-rash",
+                "probability": 97
+            },
+            "fever": {
+                "slug": "fever",
+                "probability": 79
+            },
+            "cough": {
+                "slug": "cough",
+                "probability": 40
+            },
+            "nasal-congestion": {
+                "slug": "nasal-congestion",
+                "probability": 35
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 31
+            },
+            "abnormal-appearing-skin": {
+                "slug": "abnormal-appearing-skin",
+                "probability": 27
+            },
+            "itching-of-skin": {
+                "slug": "itching-of-skin",
+                "probability": 25
+            },
+            "decreased-appetite": {
+                "slug": "decreased-appetite",
+                "probability": 17
+            },
+            "pulling-at-ears": {
+                "slug": "pulling-at-ears",
+                "probability": 11
+            },
+            "skin-swelling": {
+                "slug": "skin-swelling",
+                "probability": 8
+            },
+            "lip-sore": {
+                "slug": "lip-sore",
+                "probability": 8
+            },
+            "flu-like-syndrome": {
+                "slug": "flu-like-syndrome",
+                "probability": 8
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -90790,9 +94654,46 @@
     "viral-hepatitis": {
         "condition_name": "Viral hepatitis",
         "condition_slug": "viral-hepatitis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Viral hepatitis is liver inflammation due to a viral infection. It may present in acute (recent infection, relatively rapid onset) or chronic forms. The most common causes of viral hepatitis are the five unrelated hepatotropic viruses Hepatitis A, Hepatitis B, Hepatitis C, Hepatitis D, and Hepatitis E. In addition to the nominal hepatitis viruses, other viruses that can also cause liver inflammation include Herpes simplex, Cytomegalovirus, Epstein-Barr virus, or Yellow fever.",
+        "condition_remarks": "Within all the people who go to their doctor with viral hepatitis, 26% report having sharp abdominal pain, 13% report having drug abuse, and 13% report having abusing alcohol.",
+        "symptoms": {
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 26
+            },
+            "abusing-alcohol": {
+                "slug": "abusing-alcohol",
+                "probability": 13
+            },
+            "drug-abuse": {
+                "slug": "drug-abuse",
+                "probability": 13
+            },
+            "melena": {
+                "slug": "melena",
+                "probability": 3
+            },
+            "stomach-bloating": {
+                "slug": "stomach-bloating",
+                "probability": 2
+            },
+            "symptoms-of-the-kidneys": {
+                "slug": "symptoms-of-the-kidneys",
+                "probability": 1
+            },
+            "hand-or-finger-stiffness-or-tightness": {
+                "slug": "hand-or-finger-stiffness-or-tightness",
+                "probability": 1
+            },
+            "low-self-esteem": {
+                "slug": "low-self-esteem",
+                "probability": 1
+            },
+            "incontinence-of-stool": {
+                "slug": "incontinence-of-stool",
+                "probability": 1
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -90873,9 +94774,58 @@
     "viral-warts": {
         "condition_name": "Viral warts",
         "condition_slug": "viral-warts",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A wart is a small, rough growth resembling a cauliflower or a solid blister. It typically occurs on human\u2019s hands or feet, but often in other locations. Warts are caused by a viral infection, specifically by one of the many types of human papillomavirus (HPV). There are as many as 10 varieties of warts, the most common considered to be mostly harmless. It is possible to get warts from others; they are contagious and usually enter the body in an area of broken skin. They typically disappear after a few months but can last for years and can recur.",
+        "condition_remarks": "Within all the people who go to their doctor with viral warts, 87% report having warts, 41% report having skin lesion, and 24% report having skin growth. The symptoms that are highly suggestive of viral warts are warts, skin moles, bumps on penis, and foot or toe lump or mass, although you may still have viral warts without those symptoms.",
+        "symptoms": {
+            "warts": {
+                "slug": "warts",
+                "probability": 87
+            },
+            "skin-lesion": {
+                "slug": "skin-lesion",
+                "probability": 41
+            },
+            "skin-growth": {
+                "slug": "skin-growth",
+                "probability": 24
+            },
+            "abnormal-appearing-skin": {
+                "slug": "abnormal-appearing-skin",
+                "probability": 23
+            },
+            "skin-moles": {
+                "slug": "skin-moles",
+                "probability": 17
+            },
+            "acne-or-pimples": {
+                "slug": "acne-or-pimples",
+                "probability": 16
+            },
+            "bumps-on-penis": {
+                "slug": "bumps-on-penis",
+                "probability": 12
+            },
+            "skin-swelling": {
+                "slug": "skin-swelling",
+                "probability": 11
+            },
+            "skin-dryness-peeling-scaliness-or-roughness": {
+                "slug": "skin-dryness-peeling-scaliness-or-roughness",
+                "probability": 11
+            },
+            "lip-swelling": {
+                "slug": "lip-swelling",
+                "probability": 4
+            },
+            "too-little-hair": {
+                "slug": "too-little-hair",
+                "probability": 4
+            },
+            "foot-or-toe-lump-or-mass": {
+                "slug": "foot-or-toe-lump-or-mass",
+                "probability": 4
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -90956,9 +94906,58 @@
     "vitamin-a-deficiency": {
         "condition_name": "Vitamin A deficiency",
         "condition_slug": "vitamin-a-deficiency",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Vitamin A deficiency is a lack of vitamin A in humans. It is common in poorer countries but rarely seen in more developed countries that are wealthier. Night blindness is one of the first signs of vitamin A deficiency. Xerophthalmia, keratomalacia, and complete blindness can also occur since Vitamin A has a major role in phototransduction. Approximately 250,000 to 500,000 malnourished children in the developing world go blind each year from a deficiency of vitamin A, approximately half of whom die within a year of becoming blind. The United Nations Special Session on Children in 2002 set the elimination of vitamin A deficiency by 2010. The prevalence of night blindness due to vitamin A deficiency is also high among pregnant women in many developing countries. Vitamin A deficiency also contributes to maternal mortality and other poor outcomes in pregnancy and lactation.",
+        "condition_remarks": "Within all the people who go to their doctor with vitamin a deficiency, 84% report having hand or finger pain, 84% report having fatigue, and 14% report having preoccupation with sex. The symptoms that are highly suggestive of vitamin a deficiency are fatigue, hand or finger pain, knee lump or mass, eye strain, excessive growth, pelvic pressure, bedwetting, vulvar sore, loss of sex drive, neck cramps or spasms, joint stiffness or tightness, and shoulder swelling, although you may still have vitamin a deficiency without those symptoms.",
+        "symptoms": {
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 84
+            },
+            "hand-or-finger-pain": {
+                "slug": "hand-or-finger-pain",
+                "probability": 84
+            },
+            "knee-lump-or-mass": {
+                "slug": "knee-lump-or-mass",
+                "probability": 14
+            },
+            "eye-strain": {
+                "slug": "eye-strain",
+                "probability": 14
+            },
+            "excessive-growth": {
+                "slug": "excessive-growth",
+                "probability": 14
+            },
+            "pelvic-pressure": {
+                "slug": "pelvic-pressure",
+                "probability": 14
+            },
+            "bedwetting": {
+                "slug": "bedwetting",
+                "probability": 14
+            },
+            "vulvar-sore": {
+                "slug": "vulvar-sore",
+                "probability": 14
+            },
+            "loss-of-sex-drive": {
+                "slug": "loss-of-sex-drive",
+                "probability": 14
+            },
+            "neck-cramps-or-spasms": {
+                "slug": "neck-cramps-or-spasms",
+                "probability": 14
+            },
+            "joint-stiffness-or-tightness": {
+                "slug": "joint-stiffness-or-tightness",
+                "probability": 14
+            },
+            "shoulder-swelling": {
+                "slug": "shoulder-swelling",
+                "probability": 14
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -91039,9 +95038,58 @@
     "vitamin-b12-deficiency": {
         "condition_name": "Vitamin B12 deficiency",
         "condition_slug": "vitamin-b12-deficiency",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Vitamin B12 deficiency or hypocobalaminemia is a low blood level of vitamin B12. It can cause permanent damage to nervous tissue if left untreated longer than 6 months. Vitamin B12 itself was discovered through investigation of pernicious anemia, which is an autoimmune disease that destroys parietal cells in the stomach that secrete intrinsic factor. Pernicious anemia, if left untreated, is usually fatal within three years. Once identified, however, the condition can be treated successfully and with relative ease, although it cannot be cured and ongoing treatment is required. Humans obtain almost all of their vitamin B12 from dietary means. Pernicious anemia is usually the result of insufficient secretion of intrinsic factor within the stomach. Other more subtle types of vitamin B12 deficiency have been elucidated, including the biochemical effects, over the course of time in significant numbers.",
+        "condition_remarks": "Within all the people who go to their doctor with vitamin b12 deficiency, 36% report having fatigue, 14% report having disturbance of memory, and 14% report having paresthesia. The symptoms that are highly suggestive of vitamin b12 deficiency are abnormal appearing tongue, although you may still have vitamin b12 deficiency without those symptoms.",
+        "symptoms": {
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 36
+            },
+            "paresthesia": {
+                "slug": "paresthesia",
+                "probability": 14
+            },
+            "disturbance-of-memory": {
+                "slug": "disturbance-of-memory",
+                "probability": 14
+            },
+            "problems-with-movement": {
+                "slug": "problems-with-movement",
+                "probability": 9
+            },
+            "sweating": {
+                "slug": "sweating",
+                "probability": 6
+            },
+            "symptoms-of-the-face": {
+                "slug": "symptoms-of-the-face",
+                "probability": 6
+            },
+            "heartburn": {
+                "slug": "heartburn",
+                "probability": 6
+            },
+            "hot-flashes": {
+                "slug": "hot-flashes",
+                "probability": 6
+            },
+            "leg-cramps-or-spasms": {
+                "slug": "leg-cramps-or-spasms",
+                "probability": 3
+            },
+            "abnormal-appearing-tongue": {
+                "slug": "abnormal-appearing-tongue",
+                "probability": 3
+            },
+            "too-little-hair": {
+                "slug": "too-little-hair",
+                "probability": 3
+            },
+            "knee-stiffness-or-tightness": {
+                "slug": "knee-stiffness-or-tightness",
+                "probability": 3
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -91122,9 +95170,58 @@
     "vitamin-b-deficiency": {
         "condition_name": "Vitamin B deficiency",
         "condition_slug": "vitamin-b-deficiency",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "B vitamins are a group of water-soluble vitamins that play important roles in cell metabolism. The B vitamins were once thought to be a single vitamin, referred to as vitamin B (much as people refer to vitamin C). Later research showed that they are chemically distinct vitamins that often coexist in the same foods. In general, supplements containing all eight are referred to as a vitamin B complex. Individual B vitamin supplements are referred to by the specific name of each vitamin (e.g., B1, B2, B3 etc.).",
+        "condition_remarks": "Within all the people who go to their doctor with vitamin b deficiency, 70% report having dizziness, 41% report having muscle cramps, contractures, or spasms, and 41% report having difficulty speaking. The symptoms that are highly suggestive of vitamin b deficiency are elbow pain, allergic reaction, difficulty speaking, muscle cramps, contractures, or spasms, and abnormal involuntary movements, although you may still have vitamin b deficiency without those symptoms.",
+        "symptoms": {
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 70
+            },
+            "elbow-pain": {
+                "slug": "elbow-pain",
+                "probability": 41
+            },
+            "allergic-reaction": {
+                "slug": "allergic-reaction",
+                "probability": 41
+            },
+            "difficulty-speaking": {
+                "slug": "difficulty-speaking",
+                "probability": 41
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 41
+            },
+            "muscle-cramps-contractures-or-spasms": {
+                "slug": "muscle-cramps-contractures-or-spasms",
+                "probability": 41
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 41
+            },
+            "cough": {
+                "slug": "cough",
+                "probability": 41
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 41
+            },
+            "knee-pain": {
+                "slug": "knee-pain",
+                "probability": 41
+            },
+            "abnormal-involuntary-movements": {
+                "slug": "abnormal-involuntary-movements",
+                "probability": 41
+            },
+            "hip-pain": {
+                "slug": "hip-pain",
+                "probability": 41
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -91205,9 +95302,58 @@
     "vitamin-d-deficiency": {
         "condition_name": "Vitamin D deficiency",
         "condition_slug": "vitamin-d-deficiency",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Hypovitaminosis D is a deficiency of vitamin D. It can result from inadequate nutritional intake of vitamin D coupled with inadequate sunlight exposure (in particular sunlight with adequate ultraviolet B rays), disorders that limit vitamin D absorption, and conditions that impair the conversion of vitamin D into active metabolites including certain liver, kidney, and hereditary disorders. Deficiency results in impaired bone mineralization and leads to bone softening diseases including rickets in children and osteomalacia and osteoporosis in adults.",
+        "condition_remarks": "Within all the people who go to their doctor with vitamin d deficiency, 40% report having fatigue, 9% report having hot flashes, and 9% report having joint pain. The symptoms that are highly suggestive of vitamin d deficiency are hot flashes, infrequent menstruation, and back stiffness or tightness, although you may still have vitamin d deficiency without those symptoms.",
+        "symptoms": {
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 40
+            },
+            "joint-pain": {
+                "slug": "joint-pain",
+                "probability": 9
+            },
+            "hot-flashes": {
+                "slug": "hot-flashes",
+                "probability": 9
+            },
+            "weight-gain": {
+                "slug": "weight-gain",
+                "probability": 9
+            },
+            "skin-irritation": {
+                "slug": "skin-irritation",
+                "probability": 3
+            },
+            "arm-stiffness-or-tightness": {
+                "slug": "arm-stiffness-or-tightness",
+                "probability": 3
+            },
+            "smoking-problems": {
+                "slug": "smoking-problems",
+                "probability": 3
+            },
+            "mouth-dryness": {
+                "slug": "mouth-dryness",
+                "probability": 3
+            },
+            "infrequent-menstruation": {
+                "slug": "infrequent-menstruation",
+                "probability": 3
+            },
+            "feeling-hot": {
+                "slug": "feeling-hot",
+                "probability": 3
+            },
+            "melena": {
+                "slug": "melena",
+                "probability": 3
+            },
+            "back-stiffness-or-tightness": {
+                "slug": "back-stiffness-or-tightness",
+                "probability": 3
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -91288,9 +95434,58 @@
     "vitreous-degeneration": {
         "condition_name": "Vitreous degeneration",
         "condition_slug": "vitreous-degeneration",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Vitreous degeneration is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with vitreous degeneration, 85% report having spots or clouds in vision, 71% report having diminished vision, and 34% report having symptoms of eye. The symptoms that are highly suggestive of vitreous degeneration are spots or clouds in vision, diminished vision, symptoms of eye, lacrimation, blindness, foreign body sensation in eye, bleeding from eye, double vision, and eye burns or stings, although you may still have vitreous degeneration without those symptoms.",
+        "symptoms": {
+            "spots-or-clouds-in-vision": {
+                "slug": "spots-or-clouds-in-vision",
+                "probability": 85
+            },
+            "diminished-vision": {
+                "slug": "diminished-vision",
+                "probability": 71
+            },
+            "symptoms-of-eye": {
+                "slug": "symptoms-of-eye",
+                "probability": 34
+            },
+            "pain-in-eye": {
+                "slug": "pain-in-eye",
+                "probability": 27
+            },
+            "lacrimation": {
+                "slug": "lacrimation",
+                "probability": 24
+            },
+            "eye-redness": {
+                "slug": "eye-redness",
+                "probability": 15
+            },
+            "itchiness-of-eye": {
+                "slug": "itchiness-of-eye",
+                "probability": 15
+            },
+            "blindness": {
+                "slug": "blindness",
+                "probability": 12
+            },
+            "foreign-body-sensation-in-eye": {
+                "slug": "foreign-body-sensation-in-eye",
+                "probability": 12
+            },
+            "bleeding-from-eye": {
+                "slug": "bleeding-from-eye",
+                "probability": 8
+            },
+            "double-vision": {
+                "slug": "double-vision",
+                "probability": 8
+            },
+            "eye-burns-or-stings": {
+                "slug": "eye-burns-or-stings",
+                "probability": 8
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -91371,9 +95566,38 @@
     "vitreous-hemorrhage": {
         "condition_name": "Vitreous hemorrhage",
         "condition_slug": "vitreous-hemorrhage",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Vitreous hemorrhage is the extravasation, or leakage, of blood into the areas in and around the vitreous humor of the eye. The vitreous humor is the clear gel that fills the space between the lens and the retina of the eye. A variety of conditions can result in blood leaking into the vitreous humor, which can cause impaired vision, floaters, and photopsia.",
+        "condition_remarks": "Within all the people who go to their doctor with vitreous hemorrhage, 83% report having diminished vision, 72% report having spots or clouds in vision, and 40% report having blindness. The symptoms that are highly suggestive of vitreous hemorrhage are diminished vision, spots or clouds in vision, blindness, symptoms of eye, and bleeding from eye, although you may still have vitreous hemorrhage without those symptoms.",
+        "symptoms": {
+            "diminished-vision": {
+                "slug": "diminished-vision",
+                "probability": 83
+            },
+            "spots-or-clouds-in-vision": {
+                "slug": "spots-or-clouds-in-vision",
+                "probability": 72
+            },
+            "blindness": {
+                "slug": "blindness",
+                "probability": 40
+            },
+            "symptoms-of-eye": {
+                "slug": "symptoms-of-eye",
+                "probability": 35
+            },
+            "pain-in-eye": {
+                "slug": "pain-in-eye",
+                "probability": 30
+            },
+            "bleeding-from-eye": {
+                "slug": "bleeding-from-eye",
+                "probability": 30
+            },
+            "lacrimation": {
+                "slug": "lacrimation",
+                "probability": 10
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -91454,9 +95678,58 @@
     "vocal-cord-polyp": {
         "condition_name": "Vocal cord polyp",
         "condition_slug": "vocal-cord-polyp",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Vocal cord polyp is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with vocal cord polyp, 91% report having hoarse voice, 47% report having sore throat, and 27% report having difficulty speaking. The symptoms that are highly suggestive of vocal cord polyp are hoarse voice, difficulty speaking, throat swelling, and lump in throat, although you may still have vocal cord polyp without those symptoms.",
+        "symptoms": {
+            "hoarse-voice": {
+                "slug": "hoarse-voice",
+                "probability": 91
+            },
+            "sore-throat": {
+                "slug": "sore-throat",
+                "probability": 47
+            },
+            "difficulty-speaking": {
+                "slug": "difficulty-speaking",
+                "probability": 27
+            },
+            "cough": {
+                "slug": "cough",
+                "probability": 27
+            },
+            "nasal-congestion": {
+                "slug": "nasal-congestion",
+                "probability": 27
+            },
+            "throat-swelling": {
+                "slug": "throat-swelling",
+                "probability": 19
+            },
+            "diminished-hearing": {
+                "slug": "diminished-hearing",
+                "probability": 19
+            },
+            "lump-in-throat": {
+                "slug": "lump-in-throat",
+                "probability": 19
+            },
+            "throat-feels-tight": {
+                "slug": "throat-feels-tight",
+                "probability": 11
+            },
+            "difficulty-in-swallowing": {
+                "slug": "difficulty-in-swallowing",
+                "probability": 11
+            },
+            "skin-swelling": {
+                "slug": "skin-swelling",
+                "probability": 11
+            },
+            "retention-of-urine": {
+                "slug": "retention-of-urine",
+                "probability": 11
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -91537,9 +95810,58 @@
     "volvulus": {
         "condition_name": "Volvulus",
         "condition_slug": "volvulus",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A volvulus is a bowel obstruction where the loop of bowel has completely twisted around its site of mesenteric attachment.",
+        "condition_remarks": "Within all the people who go to their doctor with volvulus, 90% report having sharp abdominal pain, 65% report having vomiting, and 47% report having constipation. The symptoms that are highly suggestive of volvulus are constipation, peripheral edema, elbow cramps or spasms, elbow weakness, and excessive growth, although you may still have volvulus without those symptoms.",
+        "symptoms": {
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 90
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 65
+            },
+            "constipation": {
+                "slug": "constipation",
+                "probability": 47
+            },
+            "burning-abdominal-pain": {
+                "slug": "burning-abdominal-pain",
+                "probability": 47
+            },
+            "peripheral-edema": {
+                "slug": "peripheral-edema",
+                "probability": 47
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 47
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 47
+            },
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 47
+            },
+            "diarrhea": {
+                "slug": "diarrhea",
+                "probability": 47
+            },
+            "elbow-cramps-or-spasms": {
+                "slug": "elbow-cramps-or-spasms",
+                "probability": 4
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 4
+            },
+            "excessive-growth": {
+                "slug": "excessive-growth",
+                "probability": 4
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -91620,9 +95942,58 @@
     "von-hippel-lindau-disease": {
         "condition_name": "Von Hippel-Lindau disease",
         "condition_slug": "von-hippel-lindau-disease",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Von Hippel\u2013Lindau (VHL) disease is a rare, autosomal dominant genetic condition that predisposes individuals to benign and malignant tumours. The most common tumours found in VHL are central nervous system and retinal hemangioblastomas, clear cell renal carcinomas, pheochromocytomas, pancreatic neuroendocrine tumours, pancreatic cysts, endolymphatic sac tumors and epididymal papillary cystadenomas. VHL results from a mutation in the von Hippel\u2013Lindau tumor suppressor gene on chromosome 3p25.3.",
+        "condition_remarks": "Within all the people who go to their doctor with von hippel-lindau disease, 49% report having seizures, 32% report having excessive growth, and 32% report having kidney mass. The symptoms that are highly suggestive of von hippel-lindau disease are excessive growth and kidney mass, although you may still have von hippel-lindau disease without those symptoms.",
+        "symptoms": {
+            "seizures": {
+                "slug": "seizures",
+                "probability": 49
+            },
+            "upper-abdominal-pain": {
+                "slug": "upper-abdominal-pain",
+                "probability": 32
+            },
+            "excessive-growth": {
+                "slug": "excessive-growth",
+                "probability": 32
+            },
+            "abnormal-appearing-skin": {
+                "slug": "abnormal-appearing-skin",
+                "probability": 32
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 32
+            },
+            "blood-in-urine": {
+                "slug": "blood-in-urine",
+                "probability": 32
+            },
+            "paresthesia": {
+                "slug": "paresthesia",
+                "probability": 32
+            },
+            "diminished-vision": {
+                "slug": "diminished-vision",
+                "probability": 32
+            },
+            "knee-pain": {
+                "slug": "knee-pain",
+                "probability": 32
+            },
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 32
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 32
+            },
+            "kidney-mass": {
+                "slug": "kidney-mass",
+                "probability": 32
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -91703,9 +96074,58 @@
     "von-willebrand-disease": {
         "condition_name": "Von Willebrand disease",
         "condition_slug": "von-willebrand-disease",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Von Willebrand disease (vWD) is the most common hereditary coagulation abnormality described in humans, although it can also be acquired as a result of other medical conditions. It arises from a qualitative or quantitative deficiency of von Willebrand factor (vWF), a multimeric protein that is required for platelet adhesion. It is known to affect humans and dogs (notably Doberman Pinschers), and rarely swine, cattle, horses, and cats. There are three forms of vWD: inherited, acquired and pseudo or platelet type. There are three types of hereditary vWD: vWD Type I, vWD Type II and vWD III. Within the three inherited types of vWD there are various subtypes. Platelet type vWD is also an inherited condition.",
+        "condition_remarks": "Within all the people who go to their doctor with von willebrand disease, 58% report having nosebleed, 20% report having itchy scalp, and 20% report having long menstrual periods. The symptoms that are highly suggestive of von willebrand disease are nosebleed, itchy scalp, long menstrual periods, heavy menstrual flow, muscle swelling, low back weakness, and abnormal size or shape of ear, although you may still have von willebrand disease without those symptoms.",
+        "symptoms": {
+            "nosebleed": {
+                "slug": "nosebleed",
+                "probability": 58
+            },
+            "itchy-scalp": {
+                "slug": "itchy-scalp",
+                "probability": 20
+            },
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 20
+            },
+            "long-menstrual-periods": {
+                "slug": "long-menstrual-periods",
+                "probability": 20
+            },
+            "wrist-pain": {
+                "slug": "wrist-pain",
+                "probability": 20
+            },
+            "blood-in-stool": {
+                "slug": "blood-in-stool",
+                "probability": 20
+            },
+            "arm-pain": {
+                "slug": "arm-pain",
+                "probability": 20
+            },
+            "heavy-menstrual-flow": {
+                "slug": "heavy-menstrual-flow",
+                "probability": 20
+            },
+            "burning-abdominal-pain": {
+                "slug": "burning-abdominal-pain",
+                "probability": 20
+            },
+            "muscle-swelling": {
+                "slug": "muscle-swelling",
+                "probability": 1
+            },
+            "low-back-weakness": {
+                "slug": "low-back-weakness",
+                "probability": 1
+            },
+            "abnormal-size-or-shape-of-ear": {
+                "slug": "abnormal-size-or-shape-of-ear",
+                "probability": 1
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -91786,9 +96206,58 @@
     "vulvar-cancer": {
         "condition_name": "Vulvar cancer",
         "condition_slug": "vulvar-cancer",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Vulvar cancer, a malignant invasive growth in the vulva, accounts for about 4% of all gynecological cancers and typically affects women in later life. It is estimated that in the United States in 2006 about 3,740 new cases will be diagnosed and about 880 women will die as a result of vulvar cancer Vulvar carcinoma is separated from vulvar intraepithelial neoplasia (VIN), a non-invasive lesion of the epithelium that can progress via carcinoma-in-situ to squamous cell cancer, and from Paget disease of the vulva.",
+        "condition_remarks": "Within all the people who go to their doctor with vulvar cancer, 37% report having ache all over, 37% report having back pain, and 23% report having fluid retention. The symptoms that are highly suggestive of vulvar cancer are emotional symptoms and elbow weakness, although you may still have vulvar cancer without those symptoms.",
+        "symptoms": {
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 37
+            },
+            "ache-all-over": {
+                "slug": "ache-all-over",
+                "probability": 37
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 23
+            },
+            "abnormal-involuntary-movements": {
+                "slug": "abnormal-involuntary-movements",
+                "probability": 23
+            },
+            "insomnia": {
+                "slug": "insomnia",
+                "probability": 23
+            },
+            "lump-or-mass-of-breast": {
+                "slug": "lump-or-mass-of-breast",
+                "probability": 23
+            },
+            "weakness": {
+                "slug": "weakness",
+                "probability": 23
+            },
+            "fluid-retention": {
+                "slug": "fluid-retention",
+                "probability": 23
+            },
+            "peripheral-edema": {
+                "slug": "peripheral-edema",
+                "probability": 23
+            },
+            "feeling-ill": {
+                "slug": "feeling-ill",
+                "probability": 23
+            },
+            "emotional-symptoms": {
+                "slug": "emotional-symptoms",
+                "probability": 1
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 1
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -91869,9 +96338,58 @@
     "vulvar-disorder": {
         "condition_name": "Vulvar disorder",
         "condition_slug": "vulvar-disorder",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Symptoms may include redness, itching, pain, or cracks in the skin. Treatment depends on the cause.",
+        "condition_remarks": "Within all the people who go to their doctor with vulvar disorder, 39% report having vaginal discharge, 39% report having skin lesion, and 35% report having vulvar irritation. The symptoms that are highly suggestive of vulvar disorder are vaginal discharge, vulvar irritation, vulvar sore, vaginal pain, vaginal itching, and pain during intercourse, although you may still have vulvar disorder without those symptoms.",
+        "symptoms": {
+            "skin-lesion": {
+                "slug": "skin-lesion",
+                "probability": 39
+            },
+            "vaginal-discharge": {
+                "slug": "vaginal-discharge",
+                "probability": 39
+            },
+            "vulvar-irritation": {
+                "slug": "vulvar-irritation",
+                "probability": 35
+            },
+            "vulvar-sore": {
+                "slug": "vulvar-sore",
+                "probability": 30
+            },
+            "vaginal-pain": {
+                "slug": "vaginal-pain",
+                "probability": 30
+            },
+            "skin-growth": {
+                "slug": "skin-growth",
+                "probability": 24
+            },
+            "vaginal-itching": {
+                "slug": "vaginal-itching",
+                "probability": 24
+            },
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 24
+            },
+            "pain-during-intercourse": {
+                "slug": "pain-during-intercourse",
+                "probability": 17
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 17
+            },
+            "lump-or-mass-of-breast": {
+                "slug": "lump-or-mass-of-breast",
+                "probability": 17
+            },
+            "skin-dryness-peeling-scaliness-or-roughness": {
+                "slug": "skin-dryness-peeling-scaliness-or-roughness",
+                "probability": 10
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -91952,9 +96470,58 @@
     "vulvodynia": {
         "condition_name": "Vulvodynia",
         "condition_slug": "vulvodynia",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Vulvodynia is a chronic pain syndrome that affects the vulvar area and often occurs without an identifiable cause or visible pathology categorized in the ICD-9 group 625\u2014specifically ICD-9 625.7, which is for pain and other disorders of the female genital organs. It refers to pain of the vulva unexplained by vulvar or vaginal infection or skin disease.",
+        "condition_remarks": "Within all the people who go to their doctor with vulvodynia, 76% report having pelvic pain, 74% report having sharp abdominal pain, and 52% report having lower abdominal pain. The symptoms that are highly suggestive of vulvodynia are pelvic pain, lower abdominal pain, vaginal pain, and cramps and spasms, although you may still have vulvodynia without those symptoms.",
+        "symptoms": {
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 76
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 74
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 52
+            },
+            "pain-during-pregnancy": {
+                "slug": "pain-during-pregnancy",
+                "probability": 34
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 25
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 24
+            },
+            "vaginal-pain": {
+                "slug": "vaginal-pain",
+                "probability": 23
+            },
+            "side-pain": {
+                "slug": "side-pain",
+                "probability": 22
+            },
+            "vaginal-discharge": {
+                "slug": "vaginal-discharge",
+                "probability": 20
+            },
+            "burning-abdominal-pain": {
+                "slug": "burning-abdominal-pain",
+                "probability": 19
+            },
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 17
+            },
+            "cramps-and-spasms": {
+                "slug": "cramps-and-spasms",
+                "probability": 16
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -92035,9 +96602,58 @@
     "wernicke-korsakoff-syndrome": {
         "condition_name": "Wernicke Korsakoff syndrome",
         "condition_slug": "wernicke-korsakoff-syndrome",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "An acquired cognitive disorder characterized by inattentiveness and the inability to form short term memories. This disorder is frequently associated with chronic ALCOHOLISM; but it may also result from dietary deficiencies; CRANIOCEREBRAL TRAUMA; NEOPLASMS; CEREBROVASCULAR DISORDERS; ENCEPHALITIS; EPILEPSY; and other conditions. (Adams et al., Principles of Neurology, 6th ed, p1139)",
+        "condition_remarks": "Within all the people who go to their doctor with wernicke korsakoff syndrome, 74% report having depressive or psychotic symptoms, 49% report having delusions or hallucinations, and 49% report having abusing alcohol. The symptoms that are highly suggestive of wernicke korsakoff syndrome are depressive or psychotic symptoms, abusing alcohol, delusions or hallucinations, hostile behavior, vomiting blood, and disturbance of memory, although you may still have wernicke korsakoff syndrome without those symptoms.",
+        "symptoms": {
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 74
+            },
+            "abusing-alcohol": {
+                "slug": "abusing-alcohol",
+                "probability": 49
+            },
+            "delusions-or-hallucinations": {
+                "slug": "delusions-or-hallucinations",
+                "probability": 49
+            },
+            "leg-pain": {
+                "slug": "leg-pain",
+                "probability": 32
+            },
+            "fainting": {
+                "slug": "fainting",
+                "probability": 32
+            },
+            "hostile-behavior": {
+                "slug": "hostile-behavior",
+                "probability": 32
+            },
+            "paresthesia": {
+                "slug": "paresthesia",
+                "probability": 32
+            },
+            "arm-pain": {
+                "slug": "arm-pain",
+                "probability": 32
+            },
+            "anxiety-and-nervousness": {
+                "slug": "anxiety-and-nervousness",
+                "probability": 32
+            },
+            "vomiting-blood": {
+                "slug": "vomiting-blood",
+                "probability": 32
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 32
+            },
+            "disturbance-of-memory": {
+                "slug": "disturbance-of-memory",
+                "probability": 32
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -92118,9 +96734,58 @@
     "west-nile-virus": {
         "condition_name": "West Nile virus",
         "condition_slug": "west-nile-virus",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "West Nile virus (WNV) is a mosquito-borne zoonotic arbovirus belonging to the genus Flavivirus in the family Flaviviridae. This flavivirus is found in temperate and tropical regions of the world. It was first identified in the West Nile subregion in the East African nation of Uganda in 1937. Prior to the mid-1990s, WNV disease occurred only sporadically and was considered a minor risk for humans, until an outbreak in Algeria in 1994, with cases of WNV-caused encephalitis, and the first large outbreak in Romania in 1996, with a high number of cases with neuroinvasive disease. WNV has now spread globally, with the first case in the Western Hemisphere being identified in New York City in 1999; over the next 5 years, the virus spread across the continental United States, north into Canada, and southward into the Caribbean Islands and Latin America. WNV also spread to Europe, beyond the Mediterranean Basin . WNV is now considered to be an endemic pathogen in Africa, Asia, Australia, the Middle East, Europe and in the United States, which in 2012 has experienced one of its worst epidemics. In 2012, WNV killed 286 people in the United States, with the state of Texas being hard hit by this virus, making the year the deadliest on record for the United States.",
+        "condition_remarks": "Within all the people who go to their doctor with west nile virus, 91% report having preoccupation with sex, 91% report having wrist cramps or spasms, and 91% report having joint cramps or spasms. The symptoms that are highly suggestive of west nile virus are pain in eye, shoulder cramps or spasms, facial pain, ankle pain, wrist pain, pain during pregnancy, excessive anger, joint stiffness or tightness, pain or soreness of breast, knee lump or mass, fatigue, and excessive urination at night, although you may still have west nile virus without those symptoms.",
+        "symptoms": {
+            "pain-in-eye": {
+                "slug": "pain-in-eye",
+                "probability": 91
+            },
+            "shoulder-cramps-or-spasms": {
+                "slug": "shoulder-cramps-or-spasms",
+                "probability": 91
+            },
+            "facial-pain": {
+                "slug": "facial-pain",
+                "probability": 91
+            },
+            "ankle-pain": {
+                "slug": "ankle-pain",
+                "probability": 91
+            },
+            "wrist-pain": {
+                "slug": "wrist-pain",
+                "probability": 91
+            },
+            "pain-during-pregnancy": {
+                "slug": "pain-during-pregnancy",
+                "probability": 91
+            },
+            "excessive-anger": {
+                "slug": "excessive-anger",
+                "probability": 91
+            },
+            "joint-stiffness-or-tightness": {
+                "slug": "joint-stiffness-or-tightness",
+                "probability": 91
+            },
+            "pain-or-soreness-of-breast": {
+                "slug": "pain-or-soreness-of-breast",
+                "probability": 91
+            },
+            "knee-lump-or-mass": {
+                "slug": "knee-lump-or-mass",
+                "probability": 91
+            },
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 91
+            },
+            "excessive-urination-at-night": {
+                "slug": "excessive-urination-at-night",
+                "probability": 91
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -92201,9 +96866,58 @@
     "white-blood-cell-disease": {
         "condition_name": "White blood cell disease",
         "condition_slug": "white-blood-cell-disease",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "White blood cells, or leukocytes (also spelled \"leucocytes\") are cells of the immune system involved in defending the body against both infectious disease and foreign materials. Five different and diverse types of leukocytes exist, but they are all produced and derived from a multipotent cell in the bone marrow known as a hematopoietic stem cell. They live for about three to four days in the average human body. Leukocytes are found throughout the body, including the blood and lymphatic system.",
+        "condition_remarks": "Within all the people who go to their doctor with white blood cell disease, 61% report having fever, 47% report having vomiting, and 41% report having sharp abdominal pain.",
+        "symptoms": {
+            "fever": {
+                "slug": "fever",
+                "probability": 61
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 47
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 41
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 39
+            },
+            "cough": {
+                "slug": "cough",
+                "probability": 33
+            },
+            "diarrhea": {
+                "slug": "diarrhea",
+                "probability": 28
+            },
+            "weakness": {
+                "slug": "weakness",
+                "probability": 28
+            },
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 21
+            },
+            "chills": {
+                "slug": "chills",
+                "probability": 10
+            },
+            "fluid-retention": {
+                "slug": "fluid-retention",
+                "probability": 10
+            },
+            "mouth-pain": {
+                "slug": "mouth-pain",
+                "probability": 5
+            },
+            "heartburn": {
+                "slug": "heartburn",
+                "probability": 5
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -92284,9 +96998,58 @@
     "whooping-cough": {
         "condition_name": "Whooping cough",
         "condition_slug": "whooping-cough",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Pertussis \u2014 commonly called whooping cough (/\u02c8hu\u02d0p\u026a\u014b k\u0252f/ or /\u02c8hwu\u02d0p\u026a\u014b k\u0252f/) \u2014 is a highly contagious bacterial disease caused by Bordetella pertussis. In some countries, this disease is called the 100 days' cough or cough of 100 days.",
+        "condition_remarks": "Within all the people who go to their doctor with whooping cough, 98% report having cough, 68% report having shortness of breath, and 68% report having fever. The symptoms that are highly suggestive of whooping cough are cough, irritable infant, and sinus congestion, although you may still have whooping cough without those symptoms. People with whooping cough almost always have cough.",
+        "symptoms": {
+            "cough": {
+                "slug": "cough",
+                "probability": 98
+            },
+            "fever": {
+                "slug": "fever",
+                "probability": 68
+            },
+            "shortness-of-breath": {
+                "slug": "shortness-of-breath",
+                "probability": 68
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 54
+            },
+            "sore-throat": {
+                "slug": "sore-throat",
+                "probability": 43
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 43
+            },
+            "nasal-congestion": {
+                "slug": "nasal-congestion",
+                "probability": 27
+            },
+            "coryza": {
+                "slug": "coryza",
+                "probability": 27
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 27
+            },
+            "irritable-infant": {
+                "slug": "irritable-infant",
+                "probability": 27
+            },
+            "difficulty-in-swallowing": {
+                "slug": "difficulty-in-swallowing",
+                "probability": 27
+            },
+            "sinus-congestion": {
+                "slug": "sinus-congestion",
+                "probability": 27
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -92367,9 +97130,58 @@
     "wilson-disease": {
         "condition_name": "Wilson disease",
         "condition_slug": "wilson-disease",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Wilson's disease or hepatolenticular degeneration is an autosomal recessive genetic disorder in which copper accumulates in tissues; this manifests as neurological or psychiatric symptoms and liver disease. It is treated with medication that reduces copper absorption or removes the excess copper from the body, but occasionally a liver transplant is required.",
+        "condition_remarks": "Within all the people who go to their doctor with wilson disease, 69% report having sleepiness, 51% report having abnormal breathing sounds, and 51% report having insomnia. The symptoms that are highly suggestive of wilson disease are sleepiness, diminished vision, abnormal breathing sounds, insomnia, apnea, problems with movement, difficulty in swallowing, and difficulty eating, although you may still have wilson disease without those symptoms.",
+        "symptoms": {
+            "sleepiness": {
+                "slug": "sleepiness",
+                "probability": 69
+            },
+            "diminished-vision": {
+                "slug": "diminished-vision",
+                "probability": 51
+            },
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 51
+            },
+            "abnormal-breathing-sounds": {
+                "slug": "abnormal-breathing-sounds",
+                "probability": 51
+            },
+            "insomnia": {
+                "slug": "insomnia",
+                "probability": 51
+            },
+            "cough": {
+                "slug": "cough",
+                "probability": 33
+            },
+            "apnea": {
+                "slug": "apnea",
+                "probability": 33
+            },
+            "problems-with-movement": {
+                "slug": "problems-with-movement",
+                "probability": 33
+            },
+            "fainting": {
+                "slug": "fainting",
+                "probability": 33
+            },
+            "difficulty-in-swallowing": {
+                "slug": "difficulty-in-swallowing",
+                "probability": 33
+            },
+            "weakness": {
+                "slug": "weakness",
+                "probability": 33
+            },
+            "difficulty-eating": {
+                "slug": "difficulty-eating",
+                "probability": 33
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -92450,9 +97262,58 @@
     "yeast-infection": {
         "condition_name": "Yeast infection",
         "condition_slug": "yeast-infection",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Candidiasis or thrush is a fungal infection (mycosis) of any of the Candida species (all yeasts), of which Candida albicans is the most common. Also commonly referred to as a yeast infection, candidiasis is also technically known as candidosis, moniliasis, and oidiomycosis.",
+        "condition_remarks": "Within all the people who go to their doctor with yeast infection, 62% report having vaginal itching, 58% report having vaginal discharge, and 52% report having skin rash. The symptoms that are highly suggestive of yeast infection are vaginal itching, vaginal discharge, diaper rash, and vaginal pain, although you may still have yeast infection without those symptoms.",
+        "symptoms": {
+            "vaginal-itching": {
+                "slug": "vaginal-itching",
+                "probability": 62
+            },
+            "vaginal-discharge": {
+                "slug": "vaginal-discharge",
+                "probability": 58
+            },
+            "skin-rash": {
+                "slug": "skin-rash",
+                "probability": 52
+            },
+            "diaper-rash": {
+                "slug": "diaper-rash",
+                "probability": 31
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 29
+            },
+            "itching-of-skin": {
+                "slug": "itching-of-skin",
+                "probability": 29
+            },
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 23
+            },
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 23
+            },
+            "frequent-urination": {
+                "slug": "frequent-urination",
+                "probability": 19
+            },
+            "problems-during-pregnancy": {
+                "slug": "problems-during-pregnancy",
+                "probability": 19
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 17
+            },
+            "vaginal-pain": {
+                "slug": "vaginal-pain",
+                "probability": 14
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -92533,9 +97394,30 @@
     "dislocation-of-the-patella": {
         "condition_name": "Dislocation of the patella",
         "condition_slug": "dislocation-of-the-patella",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Luxating patella (or trick knee, subluxation of patella, floating patella, or floating kneecap) is a condition in which the patella, or kneecap, dislocates or moves out of its normal location.",
+        "condition_remarks": "Within all the people who go to their doctor with dislocation of the patella, 90% report having knee pain, 22% report having knee swelling, and 12% report having knee stiffness or tightness. The symptoms that are highly suggestive of dislocation of the patella are knee pain, knee swelling, and knee stiffness or tightness, although you may still have dislocation of the patella without those symptoms.",
+        "symptoms": {
+            "knee-pain": {
+                "slug": "knee-pain",
+                "probability": 90
+            },
+            "knee-swelling": {
+                "slug": "knee-swelling",
+                "probability": 22
+            },
+            "fluid-retention": {
+                "slug": "fluid-retention",
+                "probability": 12
+            },
+            "problems-during-pregnancy": {
+                "slug": "problems-during-pregnancy",
+                "probability": 12
+            },
+            "knee-stiffness-or-tightness": {
+                "slug": "knee-stiffness-or-tightness",
+                "probability": 12
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -92616,9 +97498,50 @@
     "dislocation-of-the-shoulder": {
         "condition_name": "Dislocation of the shoulder",
         "condition_slug": "dislocation-of-the-shoulder",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A dislocated shoulder occurs when the humerus separates from the scapula at the glenohumeral joint. The shoulder joint has the greatest range of motion of any joint in the body and as a result is particularly susceptible to dislocation and subluxation. Approximately half of major joint dislocations seen in emergency departments are of the shoulder. Partial dislocation of the shoulder is referred to as subluxation.",
+        "condition_remarks": "Within all the people who go to their doctor with dislocation of the shoulder, 91% report having shoulder pain, 32% report having arm pain, and 11% report having wrist pain. The symptoms that are highly suggestive of dislocation of the shoulder are shoulder pain, shoulder stiffness or tightness, arm stiffness or tightness, and shoulder lump or mass, although you may still have dislocation of the shoulder without those symptoms.",
+        "symptoms": {
+            "shoulder-pain": {
+                "slug": "shoulder-pain",
+                "probability": 91
+            },
+            "arm-pain": {
+                "slug": "arm-pain",
+                "probability": 32
+            },
+            "wrist-pain": {
+                "slug": "wrist-pain",
+                "probability": 11
+            },
+            "shoulder-stiffness-or-tightness": {
+                "slug": "shoulder-stiffness-or-tightness",
+                "probability": 7
+            },
+            "arm-stiffness-or-tightness": {
+                "slug": "arm-stiffness-or-tightness",
+                "probability": 7
+            },
+            "arm-swelling": {
+                "slug": "arm-swelling",
+                "probability": 5
+            },
+            "redness-in-or-around-nose": {
+                "slug": "redness-in-or-around-nose",
+                "probability": 3
+            },
+            "neck-mass": {
+                "slug": "neck-mass",
+                "probability": 3
+            },
+            "leg-weakness": {
+                "slug": "leg-weakness",
+                "probability": 3
+            },
+            "shoulder-lump-or-mass": {
+                "slug": "shoulder-lump-or-mass",
+                "probability": 3
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -92699,9 +97622,58 @@
     "dislocation-of-the-vertebra": {
         "condition_name": "Dislocation of the vertebra",
         "condition_slug": "dislocation-of-the-vertebra",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Dislocation of the vertebra is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with dislocation of the vertebra, 77% report having neck pain, 70% report having back pain, and 59% report having low back pain. The symptoms that are highly suggestive of dislocation of the vertebra are neck pain, bones are painful, elbow weakness, excessive growth, feeling hot and cold, and wrist weakness, although you may still have dislocation of the vertebra without those symptoms.",
+        "symptoms": {
+            "neck-pain": {
+                "slug": "neck-pain",
+                "probability": 77
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 70
+            },
+            "low-back-pain": {
+                "slug": "low-back-pain",
+                "probability": 59
+            },
+            "bones-are-painful": {
+                "slug": "bones-are-painful",
+                "probability": 41
+            },
+            "hand-or-finger-pain": {
+                "slug": "hand-or-finger-pain",
+                "probability": 41
+            },
+            "leg-pain": {
+                "slug": "leg-pain",
+                "probability": 41
+            },
+            "loss-of-sensation": {
+                "slug": "loss-of-sensation",
+                "probability": 41
+            },
+            "arm-pain": {
+                "slug": "arm-pain",
+                "probability": 41
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 3
+            },
+            "excessive-growth": {
+                "slug": "excessive-growth",
+                "probability": 3
+            },
+            "feeling-hot-and-cold": {
+                "slug": "feeling-hot-and-cold",
+                "probability": 3
+            },
+            "wrist-weakness": {
+                "slug": "wrist-weakness",
+                "probability": 3
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -92782,9 +97754,58 @@
     "dislocation-of-the-wrist": {
         "condition_name": "Dislocation of the wrist",
         "condition_slug": "dislocation-of-the-wrist",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Dislocation of the wrist is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with dislocation of the wrist, 68% report having arm pain, 58% report having hand or finger swelling, and 58% report having elbow pain. The symptoms that are highly suggestive of dislocation of the wrist are arm pain, elbow pain, hand or finger swelling, hand or finger pain, arm stiffness or tightness, elbow weakness, wrist weakness, eye strain, feeling hot and cold, and nailbiting, although you may still have dislocation of the wrist without those symptoms.",
+        "symptoms": {
+            "arm-pain": {
+                "slug": "arm-pain",
+                "probability": 68
+            },
+            "elbow-pain": {
+                "slug": "elbow-pain",
+                "probability": 58
+            },
+            "hand-or-finger-swelling": {
+                "slug": "hand-or-finger-swelling",
+                "probability": 58
+            },
+            "hand-or-finger-pain": {
+                "slug": "hand-or-finger-pain",
+                "probability": 58
+            },
+            "depression": {
+                "slug": "depression",
+                "probability": 40
+            },
+            "arm-stiffness-or-tightness": {
+                "slug": "arm-stiffness-or-tightness",
+                "probability": 40
+            },
+            "wrist-pain": {
+                "slug": "wrist-pain",
+                "probability": 40
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 3
+            },
+            "wrist-weakness": {
+                "slug": "wrist-weakness",
+                "probability": 3
+            },
+            "eye-strain": {
+                "slug": "eye-strain",
+                "probability": 3
+            },
+            "feeling-hot-and-cold": {
+                "slug": "feeling-hot-and-cold",
+                "probability": 3
+            },
+            "nailbiting": {
+                "slug": "nailbiting",
+                "probability": 3
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -92865,9 +97886,58 @@
     "dissociative-disorder": {
         "condition_name": "Dissociative disorder",
         "condition_slug": "dissociative-disorder",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Dissociative disorders (DD) are conditions that involve disruptions or breakdowns of memory, awareness, identity or perception. People with dissociative disorders use dissociation, a defense mechanism, pathologically and involuntarily. Dissociative disorders are thought to primarily be caused by psychological trauma.",
+        "condition_remarks": "Within all the people who go to their doctor with dissociative disorder, 83% report having depressive or psychotic symptoms, 66% report having anxiety and nervousness, and 66% report having depression. The symptoms that are highly suggestive of dissociative disorder are depressive or psychotic symptoms, low self-esteem, excessive anger, back weakness, muscle swelling, elbow cramps or spasms, pus in urine, and low back weakness, although you may still have dissociative disorder without those symptoms.",
+        "symptoms": {
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 83
+            },
+            "anxiety-and-nervousness": {
+                "slug": "anxiety-and-nervousness",
+                "probability": 66
+            },
+            "depression": {
+                "slug": "depression",
+                "probability": 66
+            },
+            "low-self-esteem": {
+                "slug": "low-self-esteem",
+                "probability": 30
+            },
+            "excessive-anger": {
+                "slug": "excessive-anger",
+                "probability": 30
+            },
+            "disturbance-of-memory": {
+                "slug": "disturbance-of-memory",
+                "probability": 18
+            },
+            "delusions-or-hallucinations": {
+                "slug": "delusions-or-hallucinations",
+                "probability": 18
+            },
+            "back-weakness": {
+                "slug": "back-weakness",
+                "probability": 1
+            },
+            "muscle-swelling": {
+                "slug": "muscle-swelling",
+                "probability": 1
+            },
+            "elbow-cramps-or-spasms": {
+                "slug": "elbow-cramps-or-spasms",
+                "probability": 1
+            },
+            "pus-in-urine": {
+                "slug": "pus-in-urine",
+                "probability": 1
+            },
+            "low-back-weakness": {
+                "slug": "low-back-weakness",
+                "probability": 1
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -92948,9 +98018,58 @@
     "diverticulitis": {
         "condition_name": "Diverticulitis",
         "condition_slug": "diverticulitis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Diverticulitis is a common digestive disease which involves the formation of pouches (diverticula) within the bowel wall. This process is known as diverticulosis, and typically occurs within the large intestine, or colon, although it can occasionally occur in the small intestine as well. Diverticulitis results when one of these diverticula becomes inflamed.",
+        "condition_remarks": "Within all the people who go to their doctor with diverticulitis, 87% report having sharp abdominal pain, 60% report having lower abdominal pain, and 49% report having diarrhea. The symptoms that are highly suggestive of diverticulitis are lower abdominal pain, although you may still have diverticulitis without those symptoms.",
+        "symptoms": {
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 87
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 60
+            },
+            "diarrhea": {
+                "slug": "diarrhea",
+                "probability": 49
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 48
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 40
+            },
+            "burning-abdominal-pain": {
+                "slug": "burning-abdominal-pain",
+                "probability": 35
+            },
+            "fever": {
+                "slug": "fever",
+                "probability": 28
+            },
+            "side-pain": {
+                "slug": "side-pain",
+                "probability": 26
+            },
+            "blood-in-stool": {
+                "slug": "blood-in-stool",
+                "probability": 22
+            },
+            "upper-abdominal-pain": {
+                "slug": "upper-abdominal-pain",
+                "probability": 18
+            },
+            "constipation": {
+                "slug": "constipation",
+                "probability": 17
+            },
+            "chills": {
+                "slug": "chills",
+                "probability": 14
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -93031,9 +98150,58 @@
     "diverticulosis": {
         "condition_name": "Diverticulosis",
         "condition_slug": "diverticulosis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Diverticulosis, also known as \"diverticular disease\", is the condition of having diverticula in the colon, which are outpocketings of the colonic mucosa and submucosa through weaknesses of muscle layers in the colon wall. These are more common in the sigmoid colon, which is a common place for increased pressure. This is uncommon before the age of 40, and increases in incidence after that age.",
+        "condition_remarks": "Within all the people who go to their doctor with diverticulosis, 70% report having sharp abdominal pain, 40% report having rectal bleeding, and 40% report having constipation. The symptoms that are highly suggestive of diverticulosis are rectal bleeding, blood in stool, and melena, although you may still have diverticulosis without those symptoms.",
+        "symptoms": {
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 70
+            },
+            "rectal-bleeding": {
+                "slug": "rectal-bleeding",
+                "probability": 40
+            },
+            "constipation": {
+                "slug": "constipation",
+                "probability": 40
+            },
+            "diarrhea": {
+                "slug": "diarrhea",
+                "probability": 37
+            },
+            "blood-in-stool": {
+                "slug": "blood-in-stool",
+                "probability": 34
+            },
+            "burning-abdominal-pain": {
+                "slug": "burning-abdominal-pain",
+                "probability": 31
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 31
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 25
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 20
+            },
+            "melena": {
+                "slug": "melena",
+                "probability": 13
+            },
+            "upper-abdominal-pain": {
+                "slug": "upper-abdominal-pain",
+                "probability": 12
+            },
+            "heartburn": {
+                "slug": "heartburn",
+                "probability": 10
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -93114,9 +98282,58 @@
     "down-syndrome": {
         "condition_name": "Down syndrome",
         "condition_slug": "down-syndrome",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Down syndrome (DS) or Down's syndrome, also known as trisomy 21, is a genetic disorder caused by the presence of all or part of a third copy of chromosome 21. Down syndrome is the most common chromosome abnormality in humans. It is typically associated with a delay in cognitive ability (mental retardation, or MR) and physical growth, and a particular set of facial characteristics. The average IQ of young adults with Down syndrome is around 50, whereas young adults without the condition typically have an IQ of 100. (MR has historically been defined as an IQ below 70.) A large proportion of individuals with Down syndrome have a severe degree of intellectual disability.",
+        "condition_remarks": "Within all the people who go to their doctor with down syndrome, 35% report having nasal congestion, 35% report having fever, and 32% report having cough. The symptoms that are highly suggestive of down syndrome are lack of growth and infant feeding problem, although you may still have down syndrome without those symptoms.",
+        "symptoms": {
+            "fever": {
+                "slug": "fever",
+                "probability": 35
+            },
+            "nasal-congestion": {
+                "slug": "nasal-congestion",
+                "probability": 35
+            },
+            "cough": {
+                "slug": "cough",
+                "probability": 32
+            },
+            "seizures": {
+                "slug": "seizures",
+                "probability": 24
+            },
+            "decreased-appetite": {
+                "slug": "decreased-appetite",
+                "probability": 17
+            },
+            "lack-of-growth": {
+                "slug": "lack-of-growth",
+                "probability": 13
+            },
+            "temper-problems": {
+                "slug": "temper-problems",
+                "probability": 13
+            },
+            "fluid-in-ear": {
+                "slug": "fluid-in-ear",
+                "probability": 9
+            },
+            "apnea": {
+                "slug": "apnea",
+                "probability": 9
+            },
+            "difficulty-speaking": {
+                "slug": "difficulty-speaking",
+                "probability": 9
+            },
+            "difficulty-in-swallowing": {
+                "slug": "difficulty-in-swallowing",
+                "probability": 9
+            },
+            "infant-feeding-problem": {
+                "slug": "infant-feeding-problem",
+                "probability": 9
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -93197,9 +98414,58 @@
     "drug-abuse": {
         "condition_name": "Drug abuse",
         "condition_slug": "drug-abuse",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Substance abuse, also known as drug abuse, is a patterned use of a substance (drug) in which the user consumes the substance in amounts or with methods neither approved nor advised by medical professionals. Substance abuse/drug abuse is not limited to mood-altering or psycho-active drugs. If an activity is performed using the objects against the rules and policies of the matter (as in steroids for performance enhancement in sports), it is also called substance abuse. Therefore, mood-altering and psychoactive substances are not the only types of drugs abused. Using illicit drugs \u2013 narcotics, stimulants, depressants (sedatives), hallucinogens, cannabis, even glues and paints, are also considered to be classified as drug/substance abuse. Substance abuse often includes problems with impulse control and impulsive behaviour.",
+        "condition_remarks": "Within all the people who go to their doctor with drug abuse, 60% report having drug abuse, 51% report having depressive or psychotic symptoms, and 46% report having depression. The symptoms that are highly suggestive of drug abuse are drug abuse and antisocial behavior, although you may still have drug abuse without those symptoms.",
+        "symptoms": {
+            "drug-abuse": {
+                "slug": "drug-abuse",
+                "probability": 60
+            },
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 51
+            },
+            "depression": {
+                "slug": "depression",
+                "probability": 46
+            },
+            "abusing-alcohol": {
+                "slug": "abusing-alcohol",
+                "probability": 36
+            },
+            "anxiety-and-nervousness": {
+                "slug": "anxiety-and-nervousness",
+                "probability": 32
+            },
+            "delusions-or-hallucinations": {
+                "slug": "delusions-or-hallucinations",
+                "probability": 16
+            },
+            "antisocial-behavior": {
+                "slug": "antisocial-behavior",
+                "probability": 10
+            },
+            "sweating": {
+                "slug": "sweating",
+                "probability": 6
+            },
+            "hostile-behavior": {
+                "slug": "hostile-behavior",
+                "probability": 5
+            },
+            "excessive-anger": {
+                "slug": "excessive-anger",
+                "probability": 3
+            },
+            "fears-and-phobias": {
+                "slug": "fears-and-phobias",
+                "probability": 3
+            },
+            "smoking-problems": {
+                "slug": "smoking-problems",
+                "probability": 3
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -93280,9 +98546,50 @@
     "drug-abuse-barbiturates": {
         "condition_name": "Drug abuse (barbiturates)",
         "condition_slug": "drug-abuse-barbiturates",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Drug abuse (barbiturates) is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with drug abuse (barbiturates), 50% report having drug abuse, 43% report having abusing alcohol, and 43% report having anxiety and nervousness. The symptoms that are highly suggestive of drug abuse (barbiturates) are drug abuse and abusing alcohol, although you may still have drug abuse (barbiturates) without those symptoms.",
+        "symptoms": {
+            "drug-abuse": {
+                "slug": "drug-abuse",
+                "probability": 50
+            },
+            "abusing-alcohol": {
+                "slug": "abusing-alcohol",
+                "probability": 43
+            },
+            "anxiety-and-nervousness": {
+                "slug": "anxiety-and-nervousness",
+                "probability": 43
+            },
+            "depression": {
+                "slug": "depression",
+                "probability": 41
+            },
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 41
+            },
+            "abnormal-involuntary-movements": {
+                "slug": "abnormal-involuntary-movements",
+                "probability": 17
+            },
+            "delusions-or-hallucinations": {
+                "slug": "delusions-or-hallucinations",
+                "probability": 12
+            },
+            "slurring-words": {
+                "slug": "slurring-words",
+                "probability": 6
+            },
+            "excessive-anger": {
+                "slug": "excessive-anger",
+                "probability": 6
+            },
+            "hostile-behavior": {
+                "slug": "hostile-behavior",
+                "probability": 6
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -93363,9 +98670,54 @@
     "drug-abuse-cocaine": {
         "condition_name": "Drug abuse (cocaine)",
         "condition_slug": "drug-abuse-cocaine",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Cocaine (INN) (benzoylmethylecgonine, an ecgonine derivative) is a crystalline tropane alkaloid that is obtained from the leaves of the coca plant. The name comes from \"coca\" and the alkaloid suffix -ine, forming cocaine. It is a stimulant, an appetite suppressant, and a topical anesthetic. Biologically, cocaine acts as a serotonin\u2013norepinephrine\u2013dopamine reuptake inhibitor, also known as a triple reuptake inhibitor (TRI). It is addictive because of its effect on the mesolimbic reward pathway.",
+        "condition_remarks": "Within all the people who go to their doctor with drug abuse (cocaine), 76% report having drug abuse, 55% report having abusing alcohol, and 48% report having depressive or psychotic symptoms. The symptoms that are highly suggestive of drug abuse (cocaine) are drug abuse and abusing alcohol, although you may still have drug abuse (cocaine) without those symptoms.",
+        "symptoms": {
+            "drug-abuse": {
+                "slug": "drug-abuse",
+                "probability": 76
+            },
+            "abusing-alcohol": {
+                "slug": "abusing-alcohol",
+                "probability": 55
+            },
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 48
+            },
+            "depression": {
+                "slug": "depression",
+                "probability": 40
+            },
+            "sharp-chest-pain": {
+                "slug": "sharp-chest-pain",
+                "probability": 32
+            },
+            "delusions-or-hallucinations": {
+                "slug": "delusions-or-hallucinations",
+                "probability": 19
+            },
+            "hostile-behavior": {
+                "slug": "hostile-behavior",
+                "probability": 11
+            },
+            "excessive-anger": {
+                "slug": "excessive-anger",
+                "probability": 5
+            },
+            "fears-and-phobias": {
+                "slug": "fears-and-phobias",
+                "probability": 2
+            },
+            "nightmares": {
+                "slug": "nightmares",
+                "probability": 2
+            },
+            "hysterical-behavior": {
+                "slug": "hysterical-behavior",
+                "probability": 2
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -93446,9 +98798,58 @@
     "drug-abuse-methamphetamine": {
         "condition_name": "Drug abuse (methamphetamine)",
         "condition_slug": "drug-abuse-methamphetamine",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Drug abuse (methamphetamine) is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with drug abuse (methamphetamine), 66% report having drug abuse, 54% report having depressive or psychotic symptoms, and 39% report having anxiety and nervousness. The symptoms that are highly suggestive of drug abuse (methamphetamine) are drug abuse, fears and phobias, and hostile behavior, although you may still have drug abuse (methamphetamine) without those symptoms.",
+        "symptoms": {
+            "drug-abuse": {
+                "slug": "drug-abuse",
+                "probability": 66
+            },
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 54
+            },
+            "anxiety-and-nervousness": {
+                "slug": "anxiety-and-nervousness",
+                "probability": 39
+            },
+            "depression": {
+                "slug": "depression",
+                "probability": 39
+            },
+            "shortness-of-breath": {
+                "slug": "shortness-of-breath",
+                "probability": 28
+            },
+            "delusions-or-hallucinations": {
+                "slug": "delusions-or-hallucinations",
+                "probability": 22
+            },
+            "fears-and-phobias": {
+                "slug": "fears-and-phobias",
+                "probability": 22
+            },
+            "hostile-behavior": {
+                "slug": "hostile-behavior",
+                "probability": 22
+            },
+            "abusing-alcohol": {
+                "slug": "abusing-alcohol",
+                "probability": 18
+            },
+            "palpitations": {
+                "slug": "palpitations",
+                "probability": 14
+            },
+            "feeling-ill": {
+                "slug": "feeling-ill",
+                "probability": 10
+            },
+            "pain-during-pregnancy": {
+                "slug": "pain-during-pregnancy",
+                "probability": 10
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -93529,9 +98930,58 @@
     "drug-abuse-opioids": {
         "condition_name": "Drug abuse (opioids)",
         "condition_slug": "drug-abuse-opioids",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Opioid dependence is a medical diagnosis characterized by an individual's inability to stop using opiates (morphine, heroin, codeine, oxycodone, hydrocodone, etc.) even when objectively it is in his or her best interest to do so, and is a major component of opioid addiction. In 1964 the WHO Expert Committee on Drug Dependence introduced \"dependence\" as \"A cluster of physiological, behavioural and cognitive phenomena of variable intensity, in which the use of a psychoactive drug (or drugs) takes on a high priority. The necessary descriptive characteristics are preoccupation with a desire to obtain and take the drug and persistent drug-seeking behaviour. Determinants and problematic consequences of drug dependence may be biological, psychological or social, and usually interact\". The core concept of the WHO definition of \"drug dependence\" requires the presence of a strong desire or a sense of compulsion to take the drug; and the WHO and DSM-IV-TR clinical guidelines for a definite diagnosis of \"dependence\" require that three or more of the following six characteristic features be experienced or exhibited:",
+        "condition_remarks": "Within all the people who go to their doctor with drug abuse (opioids), 67% report having drug abuse, 46% report having depressive or psychotic symptoms, and 40% report having depression. The symptoms that are highly suggestive of drug abuse (opioids) are drug abuse, although you may still have drug abuse (opioids) without those symptoms.",
+        "symptoms": {
+            "drug-abuse": {
+                "slug": "drug-abuse",
+                "probability": 67
+            },
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 46
+            },
+            "depression": {
+                "slug": "depression",
+                "probability": 40
+            },
+            "anxiety-and-nervousness": {
+                "slug": "anxiety-and-nervousness",
+                "probability": 35
+            },
+            "abusing-alcohol": {
+                "slug": "abusing-alcohol",
+                "probability": 30
+            },
+            "insomnia": {
+                "slug": "insomnia",
+                "probability": 13
+            },
+            "delusions-or-hallucinations": {
+                "slug": "delusions-or-hallucinations",
+                "probability": 8
+            },
+            "excessive-anger": {
+                "slug": "excessive-anger",
+                "probability": 6
+            },
+            "temper-problems": {
+                "slug": "temper-problems",
+                "probability": 4
+            },
+            "antisocial-behavior": {
+                "slug": "antisocial-behavior",
+                "probability": 3
+            },
+            "low-self-esteem": {
+                "slug": "low-self-esteem",
+                "probability": 3
+            },
+            "restlessness": {
+                "slug": "restlessness",
+                "probability": 3
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -93612,9 +99062,58 @@
     "drug-poisoning-due-to-medication": {
         "condition_name": "Drug poisoning due to medication",
         "condition_slug": "drug-poisoning-due-to-medication",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "The dangers of poisoning range from short-term illness to brain damage, coma and death. To prevent poisoning it is important to use and store products exactly as their labels say. Keep dangerous products where children can't get to them. Treatment for poisoning depends on the type of poison. If you suspect someone has been poisoned, call your local poison control center right away.",
+        "condition_remarks": "Within all the people who go to their doctor with drug poisoning due to medication, 53% report having depressive or psychotic symptoms, 48% report having depression, and 18% report having drug abuse. The symptoms that are highly suggestive of drug poisoning due to medication are slurring words and stiffness all over, although you may still have drug poisoning due to medication without those symptoms.",
+        "symptoms": {
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 53
+            },
+            "depression": {
+                "slug": "depression",
+                "probability": 48
+            },
+            "drug-abuse": {
+                "slug": "drug-abuse",
+                "probability": 18
+            },
+            "fainting": {
+                "slug": "fainting",
+                "probability": 15
+            },
+            "abusing-alcohol": {
+                "slug": "abusing-alcohol",
+                "probability": 15
+            },
+            "sleepiness": {
+                "slug": "sleepiness",
+                "probability": 12
+            },
+            "slurring-words": {
+                "slug": "slurring-words",
+                "probability": 10
+            },
+            "allergic-reaction": {
+                "slug": "allergic-reaction",
+                "probability": 10
+            },
+            "fluid-retention": {
+                "slug": "fluid-retention",
+                "probability": 7
+            },
+            "delusions-or-hallucinations": {
+                "slug": "delusions-or-hallucinations",
+                "probability": 7
+            },
+            "lip-swelling": {
+                "slug": "lip-swelling",
+                "probability": 7
+            },
+            "stiffness-all-over": {
+                "slug": "stiffness-all-over",
+                "probability": 7
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -93695,9 +99194,58 @@
     "drug-reaction": {
         "condition_name": "Drug reaction",
         "condition_slug": "drug-reaction",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "An adverse drug reaction (abbreviated ADR) is an expression that describes harm associated with the use of given medications at a normal dosage during normal use. ADRs may occur following a single dose or prolonged administration of a drug or result from the combination of two or more drugs. The meaning of this expression differs from the meaning of \"side effect\", as this last expression might also imply that the effects can be beneficial. The study of ADRs is the concern of the field known as pharmacovigilance. An adverse drug event (abbreviated ADE) refers to any injury caused by the drug (at normal dosage and/or due to overdose) and any harm associated with the use of the drug (e.g. discontinuation of drug therapy). ADRs are a special type of ADEs.",
+        "condition_remarks": "Within all the people who go to their doctor with drug reaction, 68% report having skin rash, 52% report having allergic reaction, and 40% report having itching of skin. The symptoms that are highly suggestive of drug reaction are allergic reaction, itching of skin, lip swelling, and throat swelling, although you may still have drug reaction without those symptoms.",
+        "symptoms": {
+            "skin-rash": {
+                "slug": "skin-rash",
+                "probability": 68
+            },
+            "allergic-reaction": {
+                "slug": "allergic-reaction",
+                "probability": 52
+            },
+            "itching-of-skin": {
+                "slug": "itching-of-skin",
+                "probability": 40
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 35
+            },
+            "peripheral-edema": {
+                "slug": "peripheral-edema",
+                "probability": 34
+            },
+            "lip-swelling": {
+                "slug": "lip-swelling",
+                "probability": 33
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 33
+            },
+            "shortness-of-breath": {
+                "slug": "shortness-of-breath",
+                "probability": 28
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 27
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 25
+            },
+            "abnormal-appearing-skin": {
+                "slug": "abnormal-appearing-skin",
+                "probability": 22
+            },
+            "throat-swelling": {
+                "slug": "throat-swelling",
+                "probability": 18
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -93778,9 +99326,58 @@
     "drug-withdrawal": {
         "condition_name": "Drug withdrawal",
         "condition_slug": "drug-withdrawal",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Withdrawal is the group of symptoms that occur upon the abrupt discontinuation or decrease in intake of medications or recreational drugs.",
+        "condition_remarks": "Within all the people who go to their doctor with drug withdrawal, 59% report having vomiting, 53% report having nausea, and 45% report having antisocial behavior. The symptoms that are highly suggestive of drug withdrawal are antisocial behavior and chills, although you may still have drug withdrawal without those symptoms.",
+        "symptoms": {
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 59
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 53
+            },
+            "antisocial-behavior": {
+                "slug": "antisocial-behavior",
+                "probability": 45
+            },
+            "anxiety-and-nervousness": {
+                "slug": "anxiety-and-nervousness",
+                "probability": 45
+            },
+            "chills": {
+                "slug": "chills",
+                "probability": 40
+            },
+            "diarrhea": {
+                "slug": "diarrhea",
+                "probability": 38
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 38
+            },
+            "depression": {
+                "slug": "depression",
+                "probability": 36
+            },
+            "ache-all-over": {
+                "slug": "ache-all-over",
+                "probability": 36
+            },
+            "seizures": {
+                "slug": "seizures",
+                "probability": 36
+            },
+            "abnormal-involuntary-movements": {
+                "slug": "abnormal-involuntary-movements",
+                "probability": 33
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 33
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -93861,9 +99458,58 @@
     "dry-eye-of-unknown-cause": {
         "condition_name": "Dry eye of unknown cause",
         "condition_slug": "dry-eye-of-unknown-cause",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Keratoconjunctivitis sicca (KCS), also called keratitis sicca, xerophthalmia or dry eye syndrome (DES) is an eye disease caused by eye dryness, which, in turn, is caused by either decreased tear production or increased tear film evaporation. It is found in humans and some animals. The phrase \"keratoconjunctivitis sicca\" is Latin, and its translation is \"dry of the cornea and conjunctiva\".",
+        "condition_remarks": "Within all the people who go to their doctor with dry eye of unknown cause, 72% report having symptoms of eye, 69% report having diminished vision, and 50% report having pain in eye. The symptoms that are highly suggestive of dry eye of unknown cause are symptoms of eye, diminished vision, pain in eye, lacrimation, itchiness of eye, eye redness, eye burns or stings, foreign body sensation in eye, spots or clouds in vision, white discharge from eye, and abnormal movement of eyelid, although you may still have dry eye of unknown cause without those symptoms.",
+        "symptoms": {
+            "symptoms-of-eye": {
+                "slug": "symptoms-of-eye",
+                "probability": 72
+            },
+            "diminished-vision": {
+                "slug": "diminished-vision",
+                "probability": 69
+            },
+            "pain-in-eye": {
+                "slug": "pain-in-eye",
+                "probability": 50
+            },
+            "lacrimation": {
+                "slug": "lacrimation",
+                "probability": 46
+            },
+            "itchiness-of-eye": {
+                "slug": "itchiness-of-eye",
+                "probability": 45
+            },
+            "eye-redness": {
+                "slug": "eye-redness",
+                "probability": 44
+            },
+            "eye-burns-or-stings": {
+                "slug": "eye-burns-or-stings",
+                "probability": 33
+            },
+            "foreign-body-sensation-in-eye": {
+                "slug": "foreign-body-sensation-in-eye",
+                "probability": 33
+            },
+            "spots-or-clouds-in-vision": {
+                "slug": "spots-or-clouds-in-vision",
+                "probability": 29
+            },
+            "white-discharge-from-eye": {
+                "slug": "white-discharge-from-eye",
+                "probability": 10
+            },
+            "abnormal-movement-of-eyelid": {
+                "slug": "abnormal-movement-of-eyelid",
+                "probability": 9
+            },
+            "double-vision": {
+                "slug": "double-vision",
+                "probability": 7
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -93944,9 +99590,58 @@
     "dumping-syndrome": {
         "condition_name": "Dumping syndrome",
         "condition_slug": "dumping-syndrome",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Gastric dumping syndrome, or rapid gastric emptying is a condition where ingested foods bypass the stomach too rapidly and enter the small intestine largely undigested. It happens when the small intestine expands too quickly due to the presence of hyperosmolar (having increased osmolarity) food from the stomach. \"Early\" dumping begins concurrently with or immediately succeeding ingestion of a meal. Symptoms of early dumping include nausea, vomiting, bloating, cramping, diarrhea, dizziness, and fatigue. \"Late\" dumping happens one to three hours after eating. Symptoms of late dumping include weakness, sweating, and dizziness. Many people have both types. The syndrome is most often associated with gastric bypass (Roux-en-Y) surgery.",
+        "condition_remarks": "Within all the people who go to their doctor with dumping syndrome, 84% report having nausea, 68% report having weight gain, and 68% report having upper abdominal pain. The symptoms that are highly suggestive of dumping syndrome are nausea, fatigue, upper abdominal pain, weight gain, vulvar sore, excessive growth, knee lump or mass, and itchy eyelid, although you may still have dumping syndrome without those symptoms.",
+        "symptoms": {
+            "nausea": {
+                "slug": "nausea",
+                "probability": 84
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 68
+            },
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 68
+            },
+            "upper-abdominal-pain": {
+                "slug": "upper-abdominal-pain",
+                "probability": 68
+            },
+            "ear-pain": {
+                "slug": "ear-pain",
+                "probability": 68
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 68
+            },
+            "diarrhea": {
+                "slug": "diarrhea",
+                "probability": 68
+            },
+            "weight-gain": {
+                "slug": "weight-gain",
+                "probability": 68
+            },
+            "vulvar-sore": {
+                "slug": "vulvar-sore",
+                "probability": 8
+            },
+            "excessive-growth": {
+                "slug": "excessive-growth",
+                "probability": 8
+            },
+            "knee-lump-or-mass": {
+                "slug": "knee-lump-or-mass",
+                "probability": 8
+            },
+            "itchy-eyelid": {
+                "slug": "itchy-eyelid",
+                "probability": 8
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -94027,9 +99722,58 @@
     "dyshidrosis": {
         "condition_name": "Dyshidrosis",
         "condition_slug": "dyshidrosis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Dyshidrosis (also known as \"acute vesiculobullous hand eczema,\" \"cheiropompholyx,\" \"dyshidrotic eczema,\" \"pompholyx,\" and \"podopompholyx\") is a skin condition that is characterized by small blisters on the hands or feet. It is an acute, chronic, or recurrent dermatosis of the fingers, palms, and soles, characterized by a sudden onset of many deep-seated pruritic, clear vesicles; later, scaling, fissures and lichenification occur. Recurrence is common and for many can be chronic. Incidence/prevalence is said to be 1/5,000 in the United States. However, many cases of eczema are diagnosed as garden-variety atopic eczema without further investigation, so it is possible that this figure is misleading.",
+        "condition_remarks": "Within all the people who go to their doctor with dyshidrosis, 83% report having skin rash, 45% report having skin lesion, and 38% report having skin dryness, peeling, scaliness, or roughness. The symptoms that are highly suggestive of dyshidrosis are skin rash, skin dryness, peeling, scaliness, or roughness, acne or pimples, dry or flaky scalp, foot or toe lump or mass, and skin on leg or foot looks infected, although you may still have dyshidrosis without those symptoms.",
+        "symptoms": {
+            "skin-rash": {
+                "slug": "skin-rash",
+                "probability": 83
+            },
+            "skin-lesion": {
+                "slug": "skin-lesion",
+                "probability": 45
+            },
+            "skin-dryness-peeling-scaliness-or-roughness": {
+                "slug": "skin-dryness-peeling-scaliness-or-roughness",
+                "probability": 38
+            },
+            "itching-of-skin": {
+                "slug": "itching-of-skin",
+                "probability": 38
+            },
+            "abnormal-appearing-skin": {
+                "slug": "abnormal-appearing-skin",
+                "probability": 38
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 29
+            },
+            "acne-or-pimples": {
+                "slug": "acne-or-pimples",
+                "probability": 29
+            },
+            "dry-or-flaky-scalp": {
+                "slug": "dry-or-flaky-scalp",
+                "probability": 17
+            },
+            "foot-or-toe-lump-or-mass": {
+                "slug": "foot-or-toe-lump-or-mass",
+                "probability": 17
+            },
+            "frequent-urination": {
+                "slug": "frequent-urination",
+                "probability": 17
+            },
+            "ankle-pain": {
+                "slug": "ankle-pain",
+                "probability": 17
+            },
+            "skin-on-leg-or-foot-looks-infected": {
+                "slug": "skin-on-leg-or-foot-looks-infected",
+                "probability": 17
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -94110,9 +99854,58 @@
     "dysthymic-disorder": {
         "condition_name": "Dysthymic disorder",
         "condition_slug": "dysthymic-disorder",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Dysthymia (/d\u026as.\u02c8\u03b8a\u026a.mi\u02d0.\u0259/ dis-THEYE-mee-\u0259), from Ancient Greek \u03b4\u03c5\u03c3\u03b8\u03c5\u03bc\u03af\u03b1, \"melancholy\"}}), also known as neurotic depression, dysthymic disorder, and chronic depression, is a mood disorder consisting of the same cognitive and physical problems as in depression, with less severe but longer-lasting symptoms, which may persist for at least 2 years. The concept was coined by Dr. Robert Spitzer (an editor of the American Psychiatric Association's Diagnostic and Statistical Manual of Mental Disorders (DSM-III)) as a replacement for the term \"depressive personality\" in the late 1970s.",
+        "condition_remarks": "Within all the people who go to their doctor with dysthymic disorder, 76% report having depression, 72% report having anxiety and nervousness, and 44% report having depressive or psychotic symptoms. The symptoms that are highly suggestive of dysthymic disorder are depression, anxiety and nervousness, low self-esteem, and loss of sex drive, although you may still have dysthymic disorder without those symptoms.",
+        "symptoms": {
+            "depression": {
+                "slug": "depression",
+                "probability": 76
+            },
+            "anxiety-and-nervousness": {
+                "slug": "anxiety-and-nervousness",
+                "probability": 72
+            },
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 44
+            },
+            "insomnia": {
+                "slug": "insomnia",
+                "probability": 22
+            },
+            "excessive-anger": {
+                "slug": "excessive-anger",
+                "probability": 7
+            },
+            "low-self-esteem": {
+                "slug": "low-self-esteem",
+                "probability": 7
+            },
+            "disturbance-of-memory": {
+                "slug": "disturbance-of-memory",
+                "probability": 6
+            },
+            "temper-problems": {
+                "slug": "temper-problems",
+                "probability": 4
+            },
+            "fears-and-phobias": {
+                "slug": "fears-and-phobias",
+                "probability": 4
+            },
+            "slurring-words": {
+                "slug": "slurring-words",
+                "probability": 3
+            },
+            "loss-of-sex-drive": {
+                "slug": "loss-of-sex-drive",
+                "probability": 2
+            },
+            "antisocial-behavior": {
+                "slug": "antisocial-behavior",
+                "probability": 2
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -94193,9 +99986,58 @@
     "ear-drum-damage": {
         "condition_name": "Ear drum damage",
         "condition_slug": "ear-drum-damage",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Ear drum damage is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with ear drum damage, 80% report having ear pain, 60% report having diminished hearing, and 43% report having fluid in ear. The symptoms that are highly suggestive of ear drum damage are ear pain, diminished hearing, fluid in ear, redness in ear, bleeding from ear, ringing in ear, and pus draining from ear, although you may still have ear drum damage without those symptoms.",
+        "symptoms": {
+            "ear-pain": {
+                "slug": "ear-pain",
+                "probability": 80
+            },
+            "diminished-hearing": {
+                "slug": "diminished-hearing",
+                "probability": 60
+            },
+            "fluid-in-ear": {
+                "slug": "fluid-in-ear",
+                "probability": 43
+            },
+            "redness-in-ear": {
+                "slug": "redness-in-ear",
+                "probability": 41
+            },
+            "bleeding-from-ear": {
+                "slug": "bleeding-from-ear",
+                "probability": 30
+            },
+            "nasal-congestion": {
+                "slug": "nasal-congestion",
+                "probability": 28
+            },
+            "cough": {
+                "slug": "cough",
+                "probability": 25
+            },
+            "plugged-feeling-in-ear": {
+                "slug": "plugged-feeling-in-ear",
+                "probability": 22
+            },
+            "ringing-in-ear": {
+                "slug": "ringing-in-ear",
+                "probability": 16
+            },
+            "pulling-at-ears": {
+                "slug": "pulling-at-ears",
+                "probability": 13
+            },
+            "pus-draining-from-ear": {
+                "slug": "pus-draining-from-ear",
+                "probability": 9
+            },
+            "flu-like-syndrome": {
+                "slug": "flu-like-syndrome",
+                "probability": 9
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -94276,9 +100118,58 @@
     "ear-wax-impaction": {
         "condition_name": "Ear wax impaction",
         "condition_slug": "ear-wax-impaction",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Ear wax impaction is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with ear wax impaction, 81% report having plugged feeling in ear, 76% report having ear pain, and 67% report having diminished hearing. The symptoms that are highly suggestive of ear wax impaction are plugged feeling in ear, ear pain, diminished hearing, and ringing in ear, although you may still have ear wax impaction without those symptoms.",
+        "symptoms": {
+            "plugged-feeling-in-ear": {
+                "slug": "plugged-feeling-in-ear",
+                "probability": 81
+            },
+            "ear-pain": {
+                "slug": "ear-pain",
+                "probability": 76
+            },
+            "diminished-hearing": {
+                "slug": "diminished-hearing",
+                "probability": 67
+            },
+            "cough": {
+                "slug": "cough",
+                "probability": 38
+            },
+            "nasal-congestion": {
+                "slug": "nasal-congestion",
+                "probability": 32
+            },
+            "fever": {
+                "slug": "fever",
+                "probability": 27
+            },
+            "ringing-in-ear": {
+                "slug": "ringing-in-ear",
+                "probability": 16
+            },
+            "fluid-in-ear": {
+                "slug": "fluid-in-ear",
+                "probability": 10
+            },
+            "redness-in-ear": {
+                "slug": "redness-in-ear",
+                "probability": 10
+            },
+            "pulling-at-ears": {
+                "slug": "pulling-at-ears",
+                "probability": 7
+            },
+            "painful-sinuses": {
+                "slug": "painful-sinuses",
+                "probability": 6
+            },
+            "sinus-congestion": {
+                "slug": "sinus-congestion",
+                "probability": 6
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -94359,9 +100250,58 @@
     "eating-disorder": {
         "condition_name": "Eating disorder",
         "condition_slug": "eating-disorder",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Eating disorders are conditions defined by abnormal eating habits that may involve either insufficient or excessive food intake to the detriment of an individual's physical and mental health. Bulimia nervosa and anorexia nervosa are the most common specific forms in the United Kingdom. Other types of eating disorders include binge eating disorder and eating disorder not otherwise specified. Bulimia nervosa is a disorder characterized by binge eating and purging. Purging can include self-induce vomiting, over-exercising, and the usage of diuretics, enemas, and laxatives. Anorexia nervosa is characterized by extreme food restriction to the point of self-starvation and excessive weight loss. Though primarily thought of as affecting females (an estimated 5\u201310 million being affected in the U.K.), eating disorders affect males as well. An estimated 10 \u2013 15% of people with eating disorders are males (Gorgan, 1999). (an estimated 1 million U.K. males being affected). Although eating disorders are increasing all over the world among both men and women, there is evidence to suggest that it is women in the Western world who are at the highest risk of developing them and the degree of westernization increases the risk. Nearly half of all Americans personally know someone with an eating disorder. The skill to comprehend the central processes of appetite has increased tremendously since leptin was discovered, and the skill to observe the functions of the brain as well. Interactions between motivational, homeostatic and self-regulatory control processes are involved in eating behaviour, which is a key component in eating disorders.",
+        "condition_remarks": "Within all the people who go to their doctor with eating disorder, 63% report having depression, 51% report having anxiety and nervousness, and 43% report having depressive or psychotic symptoms. The symptoms that are highly suggestive of eating disorder are decreased appetite, excessive appetite, difficulty eating, and excessive anger, although you may still have eating disorder without those symptoms.",
+        "symptoms": {
+            "depression": {
+                "slug": "depression",
+                "probability": 63
+            },
+            "anxiety-and-nervousness": {
+                "slug": "anxiety-and-nervousness",
+                "probability": 51
+            },
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 43
+            },
+            "decreased-appetite": {
+                "slug": "decreased-appetite",
+                "probability": 41
+            },
+            "abusing-alcohol": {
+                "slug": "abusing-alcohol",
+                "probability": 24
+            },
+            "excessive-appetite": {
+                "slug": "excessive-appetite",
+                "probability": 24
+            },
+            "difficulty-eating": {
+                "slug": "difficulty-eating",
+                "probability": 20
+            },
+            "weight-gain": {
+                "slug": "weight-gain",
+                "probability": 17
+            },
+            "excessive-anger": {
+                "slug": "excessive-anger",
+                "probability": 13
+            },
+            "insomnia": {
+                "slug": "insomnia",
+                "probability": 13
+            },
+            "vomiting-blood": {
+                "slug": "vomiting-blood",
+                "probability": 9
+            },
+            "acne-or-pimples": {
+                "slug": "acne-or-pimples",
+                "probability": 9
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -94442,9 +100382,58 @@
     "ectopic-pregnancy": {
         "condition_name": "Ectopic pregnancy",
         "condition_slug": "ectopic-pregnancy",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "An ectopic pregnancy, or eccysis, is a complication of pregnancy in which the embryo implants outside the uterine cavity. With rare exceptions, ectopic pregnancies are not viable. Furthermore, they are dangerous for the mother, since internal haemorrhage is a life-threatening complication. Most ectopic pregnancies occur in the Fallopian tube (so-called tubal pregnancies), but implantation can also occur in the cervix, ovaries, and abdomen. An ectopic pregnancy is a potential medical emergency, and, if not treated properly, can lead to death.",
+        "condition_remarks": "Within all the people who go to their doctor with ectopic pregnancy, 79% report having sharp abdominal pain, 66% report having pain during pregnancy, and 60% report having spotting or bleeding during pregnancy. The symptoms that are highly suggestive of ectopic pregnancy are pain during pregnancy, spotting or bleeding during pregnancy, lower abdominal pain, pelvic pain, cramps and spasms, and intermenstrual bleeding, although you may still have ectopic pregnancy without those symptoms.",
+        "symptoms": {
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 79
+            },
+            "pain-during-pregnancy": {
+                "slug": "pain-during-pregnancy",
+                "probability": 66
+            },
+            "spotting-or-bleeding-during-pregnancy": {
+                "slug": "spotting-or-bleeding-during-pregnancy",
+                "probability": 60
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 60
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 48
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 27
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 24
+            },
+            "cramps-and-spasms": {
+                "slug": "cramps-and-spasms",
+                "probability": 21
+            },
+            "intermenstrual-bleeding": {
+                "slug": "intermenstrual-bleeding",
+                "probability": 21
+            },
+            "burning-abdominal-pain": {
+                "slug": "burning-abdominal-pain",
+                "probability": 21
+            },
+            "vaginal-discharge": {
+                "slug": "vaginal-discharge",
+                "probability": 13
+            },
+            "problems-during-pregnancy": {
+                "slug": "problems-during-pregnancy",
+                "probability": 13
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -94525,9 +100514,58 @@
     "ectropion": {
         "condition_name": "Ectropion",
         "condition_slug": "ectropion",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Ectropion is a medical condition in which the lower eyelid turns outwards. It is one of the notable aspects of newborns exhibiting congenital Harlequin-type ichthyosis, but ectropion can occur due to any weakening of tissue of the lower eyelid. The condition can be repaired surgically. Ectropion is also found in dogs as a genetic disorder in certain breeds.",
+        "condition_remarks": "Within all the people who go to their doctor with ectropion, 72% report having lacrimation, 66% report having pain in eye, and 58% report having abnormal movement of eyelid. The symptoms that are highly suggestive of ectropion are lacrimation, pain in eye, abnormal movement of eyelid, symptoms of eye, eye redness, spots or clouds in vision, eyelid lesion or rash, foreign body sensation in eye, swollen eye, white discharge from eye, and itchiness of eye, although you may still have ectropion without those symptoms.",
+        "symptoms": {
+            "lacrimation": {
+                "slug": "lacrimation",
+                "probability": 72
+            },
+            "pain-in-eye": {
+                "slug": "pain-in-eye",
+                "probability": 66
+            },
+            "abnormal-movement-of-eyelid": {
+                "slug": "abnormal-movement-of-eyelid",
+                "probability": 58
+            },
+            "symptoms-of-eye": {
+                "slug": "symptoms-of-eye",
+                "probability": 58
+            },
+            "eye-redness": {
+                "slug": "eye-redness",
+                "probability": 47
+            },
+            "spots-or-clouds-in-vision": {
+                "slug": "spots-or-clouds-in-vision",
+                "probability": 30
+            },
+            "eyelid-lesion-or-rash": {
+                "slug": "eyelid-lesion-or-rash",
+                "probability": 30
+            },
+            "foreign-body-sensation-in-eye": {
+                "slug": "foreign-body-sensation-in-eye",
+                "probability": 30
+            },
+            "swollen-eye": {
+                "slug": "swollen-eye",
+                "probability": 30
+            },
+            "diminished-vision": {
+                "slug": "diminished-vision",
+                "probability": 30
+            },
+            "white-discharge-from-eye": {
+                "slug": "white-discharge-from-eye",
+                "probability": 30
+            },
+            "itchiness-of-eye": {
+                "slug": "itchiness-of-eye",
+                "probability": 30
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -94608,9 +100646,58 @@
     "eczema": {
         "condition_name": "Eczema",
         "condition_slug": "eczema",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Eczema or often referred to as atopic dermatitis (from Greek \u1f14\u03ba\u03b6\u03b5\u03bc\u03b1 \u0113kzema, \"to boil over\") is a form of dermatitis, or inflammation of the epidermis (the outer layer of the skin).",
+        "condition_remarks": "Within all the people who go to their doctor with eczema, 78% report having skin rash, 49% report having itching of skin, and 45% report having abnormal appearing skin. The symptoms that are highly suggestive of eczema are skin rash, itching of skin, skin dryness, peeling, scaliness, or roughness, and irregular appearing scalp, although you may still have eczema without those symptoms.",
+        "symptoms": {
+            "skin-rash": {
+                "slug": "skin-rash",
+                "probability": 78
+            },
+            "itching-of-skin": {
+                "slug": "itching-of-skin",
+                "probability": 49
+            },
+            "abnormal-appearing-skin": {
+                "slug": "abnormal-appearing-skin",
+                "probability": 45
+            },
+            "skin-dryness-peeling-scaliness-or-roughness": {
+                "slug": "skin-dryness-peeling-scaliness-or-roughness",
+                "probability": 33
+            },
+            "skin-lesion": {
+                "slug": "skin-lesion",
+                "probability": 29
+            },
+            "cough": {
+                "slug": "cough",
+                "probability": 24
+            },
+            "allergic-reaction": {
+                "slug": "allergic-reaction",
+                "probability": 22
+            },
+            "acne-or-pimples": {
+                "slug": "acne-or-pimples",
+                "probability": 15
+            },
+            "skin-swelling": {
+                "slug": "skin-swelling",
+                "probability": 12
+            },
+            "irregular-appearing-scalp": {
+                "slug": "irregular-appearing-scalp",
+                "probability": 10
+            },
+            "skin-irritation": {
+                "slug": "skin-irritation",
+                "probability": 7
+            },
+            "warts": {
+                "slug": "warts",
+                "probability": 6
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -94691,9 +100778,58 @@
     "edward-syndrome": {
         "condition_name": "Edward syndrome",
         "condition_slug": "edward-syndrome",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Edwards syndrome (also known as Trisomy 18 ) is a genetic disorder caused by the presence of all or part of an extra 18th chromosome. This genetic condition almost always results from nondisjunction during meiosis. It is named after John Hilton Edwards, who first described the syndrome in 1960. It is the second most common autosomal trisomy, after Down's syndrome, that carries to term.",
+        "condition_remarks": "Within all the people who go to their doctor with edward syndrome, 68% report having suprapubic pain, 68% report having fever, and 8% report having preoccupation with sex. The symptoms that are highly suggestive of edward syndrome are suprapubic pain, knee lump or mass, excessive growth, vulvar sore, shoulder swelling, wrist weakness, nailbiting, itchy eyelid, cross-eyed, eye strain, and joint stiffness or tightness, although you may still have edward syndrome without those symptoms.",
+        "symptoms": {
+            "fever": {
+                "slug": "fever",
+                "probability": 68
+            },
+            "suprapubic-pain": {
+                "slug": "suprapubic-pain",
+                "probability": 68
+            },
+            "knee-lump-or-mass": {
+                "slug": "knee-lump-or-mass",
+                "probability": 8
+            },
+            "excessive-growth": {
+                "slug": "excessive-growth",
+                "probability": 8
+            },
+            "vulvar-sore": {
+                "slug": "vulvar-sore",
+                "probability": 8
+            },
+            "shoulder-swelling": {
+                "slug": "shoulder-swelling",
+                "probability": 8
+            },
+            "wrist-weakness": {
+                "slug": "wrist-weakness",
+                "probability": 8
+            },
+            "nailbiting": {
+                "slug": "nailbiting",
+                "probability": 8
+            },
+            "itchy-eyelid": {
+                "slug": "itchy-eyelid",
+                "probability": 8
+            },
+            "cross-eyed": {
+                "slug": "cross-eyed",
+                "probability": 8
+            },
+            "eye-strain": {
+                "slug": "eye-strain",
+                "probability": 8
+            },
+            "joint-stiffness-or-tightness": {
+                "slug": "joint-stiffness-or-tightness",
+                "probability": 8
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -94774,9 +100910,58 @@
     "emphysema": {
         "condition_name": "Emphysema",
         "condition_slug": "emphysema",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Emphysema is a long-term lung disease. In people with emphysema, the tissues necessary to support the shape and function of the lungs are destroyed. It is included in a group of diseases called chronic obstructive pulmonary disease or COPD. Emphysema is called an obstructive lung disease because the destruction of lung tissue around smaller sacs, called alveoli, makes these air sacs unable to hold their functional shape upon exhalation. Emphysema is most often caused by tobacco smoking and long-term exposure to air pollution.",
+        "condition_remarks": "Within all the people who go to their doctor with emphysema, 89% report having sharp chest pain, 69% report having chest tightness, and 69% report having shortness of breath. The symptoms that are highly suggestive of emphysema are sharp chest pain, chest tightness, cross-eyed, itchy eyelid, excessive growth, emotional symptoms, and elbow cramps or spasms, although you may still have emphysema without those symptoms.",
+        "symptoms": {
+            "sharp-chest-pain": {
+                "slug": "sharp-chest-pain",
+                "probability": 89
+            },
+            "shortness-of-breath": {
+                "slug": "shortness-of-breath",
+                "probability": 69
+            },
+            "chest-tightness": {
+                "slug": "chest-tightness",
+                "probability": 69
+            },
+            "cough": {
+                "slug": "cough",
+                "probability": 51
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 51
+            },
+            "ache-all-over": {
+                "slug": "ache-all-over",
+                "probability": 51
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 51
+            },
+            "cross-eyed": {
+                "slug": "cross-eyed",
+                "probability": 4
+            },
+            "itchy-eyelid": {
+                "slug": "itchy-eyelid",
+                "probability": 4
+            },
+            "excessive-growth": {
+                "slug": "excessive-growth",
+                "probability": 4
+            },
+            "emotional-symptoms": {
+                "slug": "emotional-symptoms",
+                "probability": 4
+            },
+            "elbow-cramps-or-spasms": {
+                "slug": "elbow-cramps-or-spasms",
+                "probability": 4
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -94857,9 +101042,58 @@
     "empyema": {
         "condition_name": "Empyema",
         "condition_slug": "empyema",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "An empyema (from Greek: \u1f10\u03bc\u03c0\u03cd\u03b7\u03bc\u03b1) is a collection of pus within a naturally existing anatomical cavity, such as the lung pleura. It must be differentiated from an abscess, which is a collection of pus in a newly formed cavity.",
+        "condition_remarks": "Within all the people who go to their doctor with empyema, 69% report having cough, 63% report having shortness of breath, and 44% report having hurts to breath. The symptoms that are highly suggestive of empyema are hurts to breath, although you may still have empyema without those symptoms.",
+        "symptoms": {
+            "cough": {
+                "slug": "cough",
+                "probability": 69
+            },
+            "shortness-of-breath": {
+                "slug": "shortness-of-breath",
+                "probability": 63
+            },
+            "hurts-to-breath": {
+                "slug": "hurts-to-breath",
+                "probability": 44
+            },
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 44
+            },
+            "sharp-chest-pain": {
+                "slug": "sharp-chest-pain",
+                "probability": 44
+            },
+            "coryza": {
+                "slug": "coryza",
+                "probability": 44
+            },
+            "skin-rash": {
+                "slug": "skin-rash",
+                "probability": 28
+            },
+            "leg-pain": {
+                "slug": "leg-pain",
+                "probability": 28
+            },
+            "skin-lesion": {
+                "slug": "skin-lesion",
+                "probability": 28
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 28
+            },
+            "difficulty-breathing": {
+                "slug": "difficulty-breathing",
+                "probability": 28
+            },
+            "abnormal-appearing-skin": {
+                "slug": "abnormal-appearing-skin",
+                "probability": 28
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -94940,9 +101174,58 @@
     "encephalitis": {
         "condition_name": "Encephalitis",
         "condition_slug": "encephalitis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Encephalitis (from Ancient Greek \u1f10\u03bd\u03ba\u03ad\u03c6\u03b1\u03bb\u03bf\u03c2 enk\u00e9phalos \u201cbrain\u201d, composed of \u1f10\u03bd \u201cin\u201d and \u03ba\u03ad\u03c6\u03b1\u03bb\u03bf\u03c2 \u201chead\u201d, and the medical suffix -itis \u201cinflammation\u201d) is an acute inflammation of the brain. Encephalitis with meningitis is known as meningoencephalitis. Symptoms include headache, fever, confusion, drowsiness, and fatigue. More advanced and serious symptoms include seizures or convulsions, tremors, hallucinations, and memory problems.",
+        "condition_remarks": "Within all the people who go to their doctor with encephalitis, 62% report having headache, 53% report having loss of sensation, and 53% report having seizures. The symptoms that are highly suggestive of encephalitis are disturbance of memory and leg weakness, although you may still have encephalitis without those symptoms.",
+        "symptoms": {
+            "headache": {
+                "slug": "headache",
+                "probability": 62
+            },
+            "loss-of-sensation": {
+                "slug": "loss-of-sensation",
+                "probability": 53
+            },
+            "seizures": {
+                "slug": "seizures",
+                "probability": 53
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 39
+            },
+            "leg-pain": {
+                "slug": "leg-pain",
+                "probability": 39
+            },
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 30
+            },
+            "disturbance-of-memory": {
+                "slug": "disturbance-of-memory",
+                "probability": 30
+            },
+            "problems-with-movement": {
+                "slug": "problems-with-movement",
+                "probability": 18
+            },
+            "paresthesia": {
+                "slug": "paresthesia",
+                "probability": 18
+            },
+            "insomnia": {
+                "slug": "insomnia",
+                "probability": 18
+            },
+            "joint-pain": {
+                "slug": "joint-pain",
+                "probability": 18
+            },
+            "leg-weakness": {
+                "slug": "leg-weakness",
+                "probability": 18
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -95023,9 +101306,58 @@
     "endocarditis": {
         "condition_name": "Endocarditis",
         "condition_slug": "endocarditis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Endocarditis is an inflammation of the inner layer of the heart, the endocardium. It usually involves the heart valves (native or prosthetic valves). Other structures that may be involved include the interventricular septum, the chordae tendineae, the mural endocardium, or even on intracardiac devices. Endocarditis is characterized by a prototypic lesion, the vegetation, which is a mass of platelets, fibrin, microcolonies of microorganisms, and scant in\ufb02ammatory cells. In the subacute form of infective endocarditis, the vegetation may also include a center of granulomatous tissue, which may fibrose or calcify.",
+        "condition_remarks": "Within all the people who go to their doctor with endocarditis, 47% report having shortness of breath, 37% report having dizziness, and 33% report having sharp chest pain. The symptoms that are highly suggestive of endocarditis are increased heart rate, although you may still have endocarditis without those symptoms.",
+        "symptoms": {
+            "shortness-of-breath": {
+                "slug": "shortness-of-breath",
+                "probability": 47
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 37
+            },
+            "sharp-chest-pain": {
+                "slug": "sharp-chest-pain",
+                "probability": 33
+            },
+            "palpitations": {
+                "slug": "palpitations",
+                "probability": 28
+            },
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 28
+            },
+            "weakness": {
+                "slug": "weakness",
+                "probability": 28
+            },
+            "increased-heart-rate": {
+                "slug": "increased-heart-rate",
+                "probability": 16
+            },
+            "irregular-heartbeat": {
+                "slug": "irregular-heartbeat",
+                "probability": 9
+            },
+            "leg-swelling": {
+                "slug": "leg-swelling",
+                "probability": 9
+            },
+            "lower-body-pain": {
+                "slug": "lower-body-pain",
+                "probability": 9
+            },
+            "pain-or-soreness-of-breast": {
+                "slug": "pain-or-soreness-of-breast",
+                "probability": 9
+            },
+            "chills": {
+                "slug": "chills",
+                "probability": 9
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -95106,9 +101438,58 @@
     "endometrial-cancer": {
         "condition_name": "Endometrial cancer",
         "condition_slug": "endometrial-cancer",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Endometrial cancer refers to several types of malignancies that arise from the endometrium, or lining, of the uterus. Endometrial cancers are the most common gynecologic cancers in the United States, with over 35,000 women diagnosed each year. The incidence is on a slow rise secondary to the obesity epidemic. The most common subtype, endometrioid adenocarcinoma, typically occurs within a few decades of menopause, is associated with obesity, excessive estrogen exposure, often develops in the setting of endometrial hyperplasia, and presents most often with vaginal bleeding. Endometrial carcinoma is the third most common cause of gynecologic cancer death (behind ovarian and cervical cancer). A total abdominal hysterectomy (surgical removal of the uterus) with bilateral salpingo-oophorectomy is the most common therapeutic approach.",
+        "condition_remarks": "Within all the people who go to their doctor with endometrial cancer, 76% report having vaginal bleeding after menopause, 32% report having intermenstrual bleeding, and 15% report having long menstrual periods. The symptoms that are highly suggestive of endometrial cancer are vaginal bleeding after menopause, intermenstrual bleeding, hot flashes, long menstrual periods, infrequent menstruation, and mass on vulva, although you may still have endometrial cancer without those symptoms.",
+        "symptoms": {
+            "vaginal-bleeding-after-menopause": {
+                "slug": "vaginal-bleeding-after-menopause",
+                "probability": 76
+            },
+            "intermenstrual-bleeding": {
+                "slug": "intermenstrual-bleeding",
+                "probability": 32
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 15
+            },
+            "hot-flashes": {
+                "slug": "hot-flashes",
+                "probability": 15
+            },
+            "long-menstrual-periods": {
+                "slug": "long-menstrual-periods",
+                "probability": 15
+            },
+            "vaginal-discharge": {
+                "slug": "vaginal-discharge",
+                "probability": 10
+            },
+            "vaginal-itching": {
+                "slug": "vaginal-itching",
+                "probability": 10
+            },
+            "cramps-and-spasms": {
+                "slug": "cramps-and-spasms",
+                "probability": 10
+            },
+            "unpredictable-menstruation": {
+                "slug": "unpredictable-menstruation",
+                "probability": 10
+            },
+            "infrequent-menstruation": {
+                "slug": "infrequent-menstruation",
+                "probability": 6
+            },
+            "mass-on-vulva": {
+                "slug": "mass-on-vulva",
+                "probability": 6
+            },
+            "absence-of-menstruation": {
+                "slug": "absence-of-menstruation",
+                "probability": 6
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -95189,9 +101570,58 @@
     "endometrial-hyperplasia": {
         "condition_name": "Endometrial hyperplasia",
         "condition_slug": "endometrial-hyperplasia",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Endometrial hyperplasia is a condition of excessive proliferation of the cells of the endometrium, or inner lining of the uterus.",
+        "condition_remarks": "Within all the people who go to their doctor with endometrial hyperplasia, 53% report having vaginal bleeding after menopause, 45% report having heavy menstrual flow, and 35% report having unpredictable menstruation. The symptoms that are highly suggestive of endometrial hyperplasia are vaginal bleeding after menopause, heavy menstrual flow, unpredictable menstruation, pus in sputum, muscle swelling, elbow cramps or spasms, abnormal size or shape of ear, back weakness, and low back weakness, although you may still have endometrial hyperplasia without those symptoms.",
+        "symptoms": {
+            "vaginal-bleeding-after-menopause": {
+                "slug": "vaginal-bleeding-after-menopause",
+                "probability": 53
+            },
+            "heavy-menstrual-flow": {
+                "slug": "heavy-menstrual-flow",
+                "probability": 45
+            },
+            "unpredictable-menstruation": {
+                "slug": "unpredictable-menstruation",
+                "probability": 35
+            },
+            "involuntary-urination": {
+                "slug": "involuntary-urination",
+                "probability": 21
+            },
+            "vaginal-discharge": {
+                "slug": "vaginal-discharge",
+                "probability": 21
+            },
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 21
+            },
+            "pus-in-sputum": {
+                "slug": "pus-in-sputum",
+                "probability": 1
+            },
+            "muscle-swelling": {
+                "slug": "muscle-swelling",
+                "probability": 1
+            },
+            "elbow-cramps-or-spasms": {
+                "slug": "elbow-cramps-or-spasms",
+                "probability": 1
+            },
+            "abnormal-size-or-shape-of-ear": {
+                "slug": "abnormal-size-or-shape-of-ear",
+                "probability": 1
+            },
+            "back-weakness": {
+                "slug": "back-weakness",
+                "probability": 1
+            },
+            "low-back-weakness": {
+                "slug": "low-back-weakness",
+                "probability": 1
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -95272,9 +101702,58 @@
     "endometriosis": {
         "condition_name": "Endometriosis",
         "condition_slug": "endometriosis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Endometriosis is a gynecological medical condition in which cells from the lining of the uterus (endometrium) appear and flourish outside the uterine cavity, most commonly on the membrane which lines the abdominal cavity. The uterine cavity is lined with endometrial cells, which are under the influence of female hormones. Endometrial-like cells in areas outside the uterus (endometriosis) are influenced by hormonal changes and respond in a way that is similar to the cells found inside the uterus. Symptoms often worsen with the menstrual cycle.",
+        "condition_remarks": "Within all the people who go to their doctor with endometriosis, 67% report having pelvic pain, 61% report having sharp abdominal pain, and 30% report having lower abdominal pain. The symptoms that are highly suggestive of endometriosis are pelvic pain, painful menstruation, heavy menstrual flow, infertility, intermenstrual bleeding, hot flashes, and absence of menstruation, although you may still have endometriosis without those symptoms.",
+        "symptoms": {
+            "pelvic-pain": {
+                "slug": "pelvic-pain",
+                "probability": 67
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 61
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 30
+            },
+            "painful-menstruation": {
+                "slug": "painful-menstruation",
+                "probability": 28
+            },
+            "heavy-menstrual-flow": {
+                "slug": "heavy-menstrual-flow",
+                "probability": 20
+            },
+            "burning-abdominal-pain": {
+                "slug": "burning-abdominal-pain",
+                "probability": 18
+            },
+            "infertility": {
+                "slug": "infertility",
+                "probability": 15
+            },
+            "intermenstrual-bleeding": {
+                "slug": "intermenstrual-bleeding",
+                "probability": 12
+            },
+            "hot-flashes": {
+                "slug": "hot-flashes",
+                "probability": 10
+            },
+            "absence-of-menstruation": {
+                "slug": "absence-of-menstruation",
+                "probability": 10
+            },
+            "vaginal-pain": {
+                "slug": "vaginal-pain",
+                "probability": 10
+            },
+            "chills": {
+                "slug": "chills",
+                "probability": 10
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -95355,9 +101834,58 @@
     "endophthalmitis": {
         "condition_name": "Endophthalmitis",
         "condition_slug": "endophthalmitis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Endophthalmitis is an inflammation of the internal coats of the eye. It is a possible complication of all intraocular surgeries, particularly cataract surgery, with possible loss of vision and the eye itself. Infectious etiology is the most common and various bacteria and fungi have been isolated as the cause of the endophthalmitis. Other causes include penetrating trauma and retained intraocular foreign bodies.",
+        "condition_remarks": "Within all the people who go to their doctor with endophthalmitis, 86% report having pain in eye, 83% report having eye redness, and 56% report having swollen eye. The symptoms that are highly suggestive of endophthalmitis are pain in eye, eye redness, swollen eye, itchiness of eye, mass on eyelid, painful sinuses, and lacrimation, although you may still have endophthalmitis without those symptoms.",
+        "symptoms": {
+            "pain-in-eye": {
+                "slug": "pain-in-eye",
+                "probability": 86
+            },
+            "eye-redness": {
+                "slug": "eye-redness",
+                "probability": 83
+            },
+            "swollen-eye": {
+                "slug": "swollen-eye",
+                "probability": 56
+            },
+            "diminished-vision": {
+                "slug": "diminished-vision",
+                "probability": 48
+            },
+            "itchiness-of-eye": {
+                "slug": "itchiness-of-eye",
+                "probability": 38
+            },
+            "mass-on-eyelid": {
+                "slug": "mass-on-eyelid",
+                "probability": 23
+            },
+            "paresthesia": {
+                "slug": "paresthesia",
+                "probability": 23
+            },
+            "painful-sinuses": {
+                "slug": "painful-sinuses",
+                "probability": 23
+            },
+            "skin-lesion": {
+                "slug": "skin-lesion",
+                "probability": 23
+            },
+            "foot-or-toe-pain": {
+                "slug": "foot-or-toe-pain",
+                "probability": 23
+            },
+            "lacrimation": {
+                "slug": "lacrimation",
+                "probability": 23
+            },
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 23
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -95438,9 +101966,58 @@
     "envenomation-from-spider-or-animal-bite": {
         "condition_name": "Envenomation from spider or animal bite",
         "condition_slug": "envenomation-from-spider-or-animal-bite",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Envenomation from spider or animal bite is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with envenomation from spider or animal bite, 42% report having allergic reaction, 35% report having itching of skin, and 35% report having skin rash. The symptoms that are highly suggestive of envenomation from spider or animal bite are allergic reaction, hand or finger swelling, and arm swelling, although you may still have envenomation from spider or animal bite without those symptoms.",
+        "symptoms": {
+            "allergic-reaction": {
+                "slug": "allergic-reaction",
+                "probability": 42
+            },
+            "skin-rash": {
+                "slug": "skin-rash",
+                "probability": 35
+            },
+            "itching-of-skin": {
+                "slug": "itching-of-skin",
+                "probability": 35
+            },
+            "hand-or-finger-swelling": {
+                "slug": "hand-or-finger-swelling",
+                "probability": 34
+            },
+            "abnormal-appearing-skin": {
+                "slug": "abnormal-appearing-skin",
+                "probability": 27
+            },
+            "fluid-retention": {
+                "slug": "fluid-retention",
+                "probability": 18
+            },
+            "foot-or-toe-swelling": {
+                "slug": "foot-or-toe-swelling",
+                "probability": 16
+            },
+            "arm-swelling": {
+                "slug": "arm-swelling",
+                "probability": 14
+            },
+            "leg-swelling": {
+                "slug": "leg-swelling",
+                "probability": 14
+            },
+            "peripheral-edema": {
+                "slug": "peripheral-edema",
+                "probability": 14
+            },
+            "skin-swelling": {
+                "slug": "skin-swelling",
+                "probability": 12
+            },
+            "paresthesia": {
+                "slug": "paresthesia",
+                "probability": 10
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -95521,9 +102098,58 @@
     "ependymoma": {
         "condition_name": "Ependymoma",
         "condition_slug": "ependymoma",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Ependymoma is a tumor that arises from the ependyma, a tissue of the central nervous system. Usually, in pediatric cases the location is intracranial, while in adults it is spinal. The common location of intracranial ependymoma is the fourth ventricle. Rarely, ependymoma can occur in the pelvic cavity.",
+        "condition_remarks": "Within all the people who go to their doctor with ependymoma, 68% report having diminished vision, 43% report having pain in eye, and 27% report having eyelid swelling. The symptoms that are highly suggestive of ependymoma are diminished vision, pain in eye, eyelid swelling, symptoms of eye, emotional symptoms, elbow cramps or spasms, pus in sputum, elbow weakness, and muscle swelling, although you may still have ependymoma without those symptoms.",
+        "symptoms": {
+            "diminished-vision": {
+                "slug": "diminished-vision",
+                "probability": 68
+            },
+            "pain-in-eye": {
+                "slug": "pain-in-eye",
+                "probability": 43
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 27
+            },
+            "eyelid-swelling": {
+                "slug": "eyelid-swelling",
+                "probability": 27
+            },
+            "symptoms-of-eye": {
+                "slug": "symptoms-of-eye",
+                "probability": 27
+            },
+            "abnormal-appearing-skin": {
+                "slug": "abnormal-appearing-skin",
+                "probability": 27
+            },
+            "eye-redness": {
+                "slug": "eye-redness",
+                "probability": 27
+            },
+            "emotional-symptoms": {
+                "slug": "emotional-symptoms",
+                "probability": 2
+            },
+            "elbow-cramps-or-spasms": {
+                "slug": "elbow-cramps-or-spasms",
+                "probability": 2
+            },
+            "pus-in-sputum": {
+                "slug": "pus-in-sputum",
+                "probability": 2
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 2
+            },
+            "muscle-swelling": {
+                "slug": "muscle-swelling",
+                "probability": 2
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -95604,9 +102230,58 @@
     "epididymitis": {
         "condition_name": "Epididymitis",
         "condition_slug": "epididymitis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Epididymitis ( \u02cc\u025bp\u026a\u02ccd\u026ad\u0259\u02c8ma\u026at\u026as, \u011bp'\u012d-d\u012dd'\u0259-m\u012b't\u012ds, EP-\u0259-DID-\u0259-MEYE-tis) is a medical condition characterized by discomfort or pain in of the epididymis, a curved structure at the back of the testicle in which sperm matures and is stored. Epididymitis is usually characterized as either acute or chronic: if acute, the onset of testicular pain is often accompanied by inflammation, redness, and warmth in the scrotum; if chronic, pain may be the only symptom. In either form, testicular pain in one or both testes can vary from mild to severe, and one or both epididymides may noticeably swell and/ or harden. The pain is often cyclical and may last from less than an hour to several days.",
+        "condition_remarks": "Within all the people who go to their doctor with epididymitis, 91% report having pain in testicles, 73% report having swelling of scrotum, and 46% report having groin pain. The symptoms that are highly suggestive of epididymitis are pain in testicles, swelling of scrotum, groin pain, swollen abdomen, and mass in scrotum, although you may still have epididymitis without those symptoms.",
+        "symptoms": {
+            "pain-in-testicles": {
+                "slug": "pain-in-testicles",
+                "probability": 91
+            },
+            "swelling-of-scrotum": {
+                "slug": "swelling-of-scrotum",
+                "probability": 73
+            },
+            "groin-pain": {
+                "slug": "groin-pain",
+                "probability": 46
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 30
+            },
+            "side-pain": {
+                "slug": "side-pain",
+                "probability": 20
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 18
+            },
+            "painful-urination": {
+                "slug": "painful-urination",
+                "probability": 18
+            },
+            "blood-in-urine": {
+                "slug": "blood-in-urine",
+                "probability": 15
+            },
+            "retention-of-urine": {
+                "slug": "retention-of-urine",
+                "probability": 15
+            },
+            "lower-body-pain": {
+                "slug": "lower-body-pain",
+                "probability": 11
+            },
+            "swollen-abdomen": {
+                "slug": "swollen-abdomen",
+                "probability": 8
+            },
+            "mass-in-scrotum": {
+                "slug": "mass-in-scrotum",
+                "probability": 8
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -95687,9 +102362,58 @@
     "epidural-hemorrhage": {
         "condition_name": "Epidural hemorrhage",
         "condition_slug": "epidural-hemorrhage",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Epidural or extradural hematoma (haematoma) is a type of traumatic brain injury (TBI) in which a buildup of blood occurs between the dura mater (the tough outer membrane of the central nervous system) and the skull. The dura mater also covers the spine, so epidural bleeds may also occur in the spinal column. Often due to trauma, the condition is potentially deadly because the buildup of blood may increase pressure in the intracranial space, compress delicate brain tissue, and cause brain shift. The condition is present in one to three percent of head injuries. Between 15 and 20% of epidural hematomas are fatal.",
+        "condition_remarks": "Within all the people who go to their doctor with epidural hemorrhage, 63% report having depressive or psychotic symptoms, 63% report having back pain, and 45% report having diminished hearing. The symptoms that are highly suggestive of epidural hemorrhage are diminished hearing, elbow weakness, excessive growth, low back weakness, feeling hot and cold, wrist weakness, and emotional symptoms, although you may still have epidural hemorrhage without those symptoms.",
+        "symptoms": {
+            "back-pain": {
+                "slug": "back-pain",
+                "probability": 63
+            },
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 63
+            },
+            "side-pain": {
+                "slug": "side-pain",
+                "probability": 45
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 45
+            },
+            "leg-pain": {
+                "slug": "leg-pain",
+                "probability": 45
+            },
+            "diminished-hearing": {
+                "slug": "diminished-hearing",
+                "probability": 45
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 3
+            },
+            "excessive-growth": {
+                "slug": "excessive-growth",
+                "probability": 3
+            },
+            "low-back-weakness": {
+                "slug": "low-back-weakness",
+                "probability": 3
+            },
+            "feeling-hot-and-cold": {
+                "slug": "feeling-hot-and-cold",
+                "probability": 3
+            },
+            "wrist-weakness": {
+                "slug": "wrist-weakness",
+                "probability": 3
+            },
+            "emotional-symptoms": {
+                "slug": "emotional-symptoms",
+                "probability": 3
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -95770,9 +102494,46 @@
     "epilepsy": {
         "condition_name": "Epilepsy",
         "condition_slug": "epilepsy",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Epilepsy is a common and diverse set of chronic neurological disorders characterized by seizures. Some definitions of epilepsy require that seizures be recurrent and unprovoked, but others require only a single seizure combined with brain alterations which increase the chance of future seizures. In many cases a cause cannot be identified; however, factors that are associated include brain trauma, strokes, brain cancer, and drug and alcohol misuse among others.",
+        "condition_remarks": "Within all the people who go to their doctor with epilepsy, 91% report having seizures, 32% report having headache, and 13% report having abnormal involuntary movements. The symptoms that are highly suggestive of epilepsy are seizures, although you may still have epilepsy without those symptoms.",
+        "symptoms": {
+            "seizures": {
+                "slug": "seizures",
+                "probability": 91
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 32
+            },
+            "abnormal-involuntary-movements": {
+                "slug": "abnormal-involuntary-movements",
+                "probability": 13
+            },
+            "disturbance-of-memory": {
+                "slug": "disturbance-of-memory",
+                "probability": 9
+            },
+            "difficulty-speaking": {
+                "slug": "difficulty-speaking",
+                "probability": 4
+            },
+            "lack-of-growth": {
+                "slug": "lack-of-growth",
+                "probability": 2
+            },
+            "stiffness-all-over": {
+                "slug": "stiffness-all-over",
+                "probability": 2
+            },
+            "eye-moves-abnormally": {
+                "slug": "eye-moves-abnormally",
+                "probability": 2
+            },
+            "muscle-weakness": {
+                "slug": "muscle-weakness",
+                "probability": 1
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -95853,9 +102614,58 @@
     "erectile-dysfunction": {
         "condition_name": "Erectile dysfunction",
         "condition_slug": "erectile-dysfunction",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Erectile dysfunction (ED) is sexual dysfunction characterized by the inability to develop or maintain an erection of the penis during sexual performance.",
+        "condition_remarks": "Within all the people who go to their doctor with erectile dysfunction, 84% report having impotence, 28% report having retention of urine, and 23% report having symptoms of prostate. The symptoms that are highly suggestive of erectile dysfunction are impotence, symptoms of prostate, loss of sex drive, excessive urination at night, premature ejaculation, penis pain, and pain during intercourse, although you may still have erectile dysfunction without those symptoms.",
+        "symptoms": {
+            "impotence": {
+                "slug": "impotence",
+                "probability": 84
+            },
+            "retention-of-urine": {
+                "slug": "retention-of-urine",
+                "probability": 28
+            },
+            "symptoms-of-prostate": {
+                "slug": "symptoms-of-prostate",
+                "probability": 23
+            },
+            "frequent-urination": {
+                "slug": "frequent-urination",
+                "probability": 22
+            },
+            "blood-in-urine": {
+                "slug": "blood-in-urine",
+                "probability": 16
+            },
+            "pain-in-testicles": {
+                "slug": "pain-in-testicles",
+                "probability": 14
+            },
+            "loss-of-sex-drive": {
+                "slug": "loss-of-sex-drive",
+                "probability": 12
+            },
+            "excessive-urination-at-night": {
+                "slug": "excessive-urination-at-night",
+                "probability": 11
+            },
+            "involuntary-urination": {
+                "slug": "involuntary-urination",
+                "probability": 7
+            },
+            "premature-ejaculation": {
+                "slug": "premature-ejaculation",
+                "probability": 7
+            },
+            "penis-pain": {
+                "slug": "penis-pain",
+                "probability": 7
+            },
+            "pain-during-intercourse": {
+                "slug": "pain-during-intercourse",
+                "probability": 6
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -95936,9 +102746,58 @@
     "erythema-multiforme": {
         "condition_name": "Erythema multiforme",
         "condition_slug": "erythema-multiforme",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Erythema multiforme is a skin condition of unknown cause, possibly mediated by deposition of immune complex (mostly IgM) in the superficial microvasculature of the skin and oral mucous membrane that usually follows an infection or drug exposure. It is a common disorder, with peak incidence in the second and third decades of life.",
+        "condition_remarks": "Within all the people who go to their doctor with erythema multiforme, 92% report having skin rash, 67% report having fever, and 44% report having itching of skin. The symptoms that are highly suggestive of erythema multiforme are skin rash, itching of skin, mouth ulcer, and skin pain, although you may still have erythema multiforme without those symptoms.",
+        "symptoms": {
+            "skin-rash": {
+                "slug": "skin-rash",
+                "probability": 92
+            },
+            "fever": {
+                "slug": "fever",
+                "probability": 67
+            },
+            "itching-of-skin": {
+                "slug": "itching-of-skin",
+                "probability": 44
+            },
+            "coryza": {
+                "slug": "coryza",
+                "probability": 44
+            },
+            "skin-lesion": {
+                "slug": "skin-lesion",
+                "probability": 44
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 44
+            },
+            "mouth-ulcer": {
+                "slug": "mouth-ulcer",
+                "probability": 34
+            },
+            "skin-pain": {
+                "slug": "skin-pain",
+                "probability": 20
+            },
+            "pain-in-eye": {
+                "slug": "pain-in-eye",
+                "probability": 20
+            },
+            "fluid-retention": {
+                "slug": "fluid-retention",
+                "probability": 20
+            },
+            "allergic-reaction": {
+                "slug": "allergic-reaction",
+                "probability": 20
+            },
+            "difficulty-in-swallowing": {
+                "slug": "difficulty-in-swallowing",
+                "probability": 20
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -96019,9 +102878,58 @@
     "esophageal-cancer": {
         "condition_name": "Esophageal cancer",
         "condition_slug": "esophageal-cancer",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Esophageal cancer (or oesophageal cancer) is malignancy of the esophagus. There are various subtypes, primarily squamous cell cancer (approx 90\u201395% of all esophageal cancer worldwide) and adenocarcinoma (approx. 50\u201380% of all esophageal cancer in the United States). Squamous cell cancer arises from the cells that line the upper part of the esophagus. Adenocarcinoma arises from glandular cells that are present at the junction of the esophagus and stomach.",
+        "condition_remarks": "Within all the people who go to their doctor with esophageal cancer, 32% report having fatigue, 32% report having weakness, and 32% report having ache all over.",
+        "symptoms": {
+            "fatigue": {
+                "slug": "fatigue",
+                "probability": 32
+            },
+            "ache-all-over": {
+                "slug": "ache-all-over",
+                "probability": 32
+            },
+            "weakness": {
+                "slug": "weakness",
+                "probability": 32
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 32
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 32
+            },
+            "shortness-of-breath": {
+                "slug": "shortness-of-breath",
+                "probability": 28
+            },
+            "difficulty-in-swallowing": {
+                "slug": "difficulty-in-swallowing",
+                "probability": 28
+            },
+            "decreased-appetite": {
+                "slug": "decreased-appetite",
+                "probability": 23
+            },
+            "hoarse-voice": {
+                "slug": "hoarse-voice",
+                "probability": 13
+            },
+            "mouth-pain": {
+                "slug": "mouth-pain",
+                "probability": 7
+            },
+            "changes-in-stool-appearance": {
+                "slug": "changes-in-stool-appearance",
+                "probability": 7
+            },
+            "stomach-bloating": {
+                "slug": "stomach-bloating",
+                "probability": 7
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -96102,9 +103010,58 @@
     "esophageal-varices": {
         "condition_name": "Esophageal varices",
         "condition_slug": "esophageal-varices",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "In medicine (gastroenterology), esophageal varices (or oesophageal varices) are extremely dilated sub-mucosal veins in the lower third of the esophagus. They are most often a consequence of portal hypertension, commonly due to cirrhosis; patients with esophageal varices have a strong tendency to develop bleeding.",
+        "condition_remarks": "Within all the people who go to their doctor with esophageal varices, 41% report having changes in stool appearance, 41% report having burning abdominal pain, and 41% report having nausea. The symptoms that are highly suggestive of esophageal varices are changes in stool appearance, melena, and pain of the anus, although you may still have esophageal varices without those symptoms.",
+        "symptoms": {
+            "burning-abdominal-pain": {
+                "slug": "burning-abdominal-pain",
+                "probability": 41
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 41
+            },
+            "changes-in-stool-appearance": {
+                "slug": "changes-in-stool-appearance",
+                "probability": 41
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 26
+            },
+            "weakness": {
+                "slug": "weakness",
+                "probability": 26
+            },
+            "lower-abdominal-pain": {
+                "slug": "lower-abdominal-pain",
+                "probability": 26
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 26
+            },
+            "difficulty-in-swallowing": {
+                "slug": "difficulty-in-swallowing",
+                "probability": 26
+            },
+            "melena": {
+                "slug": "melena",
+                "probability": 26
+            },
+            "itching-of-skin": {
+                "slug": "itching-of-skin",
+                "probability": 26
+            },
+            "pain-of-the-anus": {
+                "slug": "pain-of-the-anus",
+                "probability": 26
+            },
+            "decreased-appetite": {
+                "slug": "decreased-appetite",
+                "probability": 26
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -96185,9 +103142,58 @@
     "esophagitis": {
         "condition_name": "Esophagitis",
         "condition_slug": "esophagitis",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Esophagitis (or oesophagitis) is inflammation of the esophagus. It may be acute or chronic. Acute esophagitis can be catarrhal or phlegmonous, whereas chronic esophagitis may be hypertrophic or atrophic.",
+        "condition_remarks": "Within all the people who go to their doctor with esophagitis, 66% report having sharp chest pain, 53% report having sharp abdominal pain, and 50% report having vomiting. The symptoms that are highly suggestive of esophagitis are difficulty in swallowing and heartburn, although you may still have esophagitis without those symptoms.",
+        "symptoms": {
+            "sharp-chest-pain": {
+                "slug": "sharp-chest-pain",
+                "probability": 66
+            },
+            "sharp-abdominal-pain": {
+                "slug": "sharp-abdominal-pain",
+                "probability": 53
+            },
+            "vomiting": {
+                "slug": "vomiting",
+                "probability": 50
+            },
+            "difficulty-in-swallowing": {
+                "slug": "difficulty-in-swallowing",
+                "probability": 47
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 40
+            },
+            "heartburn": {
+                "slug": "heartburn",
+                "probability": 39
+            },
+            "upper-abdominal-pain": {
+                "slug": "upper-abdominal-pain",
+                "probability": 33
+            },
+            "sore-throat": {
+                "slug": "sore-throat",
+                "probability": 32
+            },
+            "cough": {
+                "slug": "cough",
+                "probability": 29
+            },
+            "shortness-of-breath": {
+                "slug": "shortness-of-breath",
+                "probability": 24
+            },
+            "burning-abdominal-pain": {
+                "slug": "burning-abdominal-pain",
+                "probability": 22
+            },
+            "chest-tightness": {
+                "slug": "chest-tightness",
+                "probability": 19
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -96268,9 +103274,58 @@
     "essential-tremor": {
         "condition_name": "Essential tremor",
         "condition_slug": "essential-tremor",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Essential tremor (ET) is a degenerative disorder of the central nervous system whose most recognizable feature is a tremor of the arms or hands during voluntary movements such as eating and writing. In many respects it resembles Idiopathic Parkinson's disease. Essential tremor is commonly described as an action tremor (it intensifies when one tries to use the affected muscles) rather than a resting tremor; rigidity, such as is seen in Parkinson\u2019s, is usually not included among its symptoms. In practice, however, there is far less difference between Essential Tremor and Parkinson's Disease than is often assumed.",
+        "condition_remarks": "Within all the people who go to their doctor with essential tremor, 95% report having abnormal involuntary movements, 35% report having problems with movement, and 30% report having dizziness. The symptoms that are highly suggestive of essential tremor are abnormal involuntary movements, problems with movement, and arm stiffness or tightness, although you may still have essential tremor without those symptoms.",
+        "symptoms": {
+            "abnormal-involuntary-movements": {
+                "slug": "abnormal-involuntary-movements",
+                "probability": 95
+            },
+            "problems-with-movement": {
+                "slug": "problems-with-movement",
+                "probability": 35
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 30
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 30
+            },
+            "seizures": {
+                "slug": "seizures",
+                "probability": 21
+            },
+            "loss-of-sensation": {
+                "slug": "loss-of-sensation",
+                "probability": 21
+            },
+            "disturbance-of-memory": {
+                "slug": "disturbance-of-memory",
+                "probability": 18
+            },
+            "muscle-pain": {
+                "slug": "muscle-pain",
+                "probability": 10
+            },
+            "painful-sinuses": {
+                "slug": "painful-sinuses",
+                "probability": 5
+            },
+            "arm-stiffness-or-tightness": {
+                "slug": "arm-stiffness-or-tightness",
+                "probability": 5
+            },
+            "hoarse-voice": {
+                "slug": "hoarse-voice",
+                "probability": 5
+            },
+            "fears-and-phobias": {
+                "slug": "fears-and-phobias",
+                "probability": 5
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -96351,9 +103406,58 @@
     "eustachian-tube-dysfunction-ear-disorder": {
         "condition_name": "Eustachian tube dysfunction (ear disorder)",
         "condition_slug": "eustachian-tube-dysfunction-ear-disorder",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Eustachian tube dysfunction (ear disorder) is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with eustachian tube dysfunction (ear disorder), 75% report having ear pain, 52% report having diminished hearing, and 50% report having plugged feeling in ear. The symptoms that are highly suggestive of eustachian tube dysfunction (ear disorder) are ear pain, diminished hearing, plugged feeling in ear, redness in ear, fluid in ear, ringing in ear, and swollen or red tonsils, although you may still have eustachian tube dysfunction (ear disorder) without those symptoms.",
+        "symptoms": {
+            "ear-pain": {
+                "slug": "ear-pain",
+                "probability": 75
+            },
+            "diminished-hearing": {
+                "slug": "diminished-hearing",
+                "probability": 52
+            },
+            "plugged-feeling-in-ear": {
+                "slug": "plugged-feeling-in-ear",
+                "probability": 50
+            },
+            "redness-in-ear": {
+                "slug": "redness-in-ear",
+                "probability": 49
+            },
+            "nasal-congestion": {
+                "slug": "nasal-congestion",
+                "probability": 45
+            },
+            "sore-throat": {
+                "slug": "sore-throat",
+                "probability": 30
+            },
+            "fluid-in-ear": {
+                "slug": "fluid-in-ear",
+                "probability": 30
+            },
+            "dizziness": {
+                "slug": "dizziness",
+                "probability": 27
+            },
+            "ringing-in-ear": {
+                "slug": "ringing-in-ear",
+                "probability": 23
+            },
+            "abnormal-breathing-sounds": {
+                "slug": "abnormal-breathing-sounds",
+                "probability": 12
+            },
+            "allergic-reaction": {
+                "slug": "allergic-reaction",
+                "probability": 11
+            },
+            "swollen-or-red-tonsils": {
+                "slug": "swollen-or-red-tonsils",
+                "probability": 10
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -96434,9 +103538,58 @@
     "extrapyramidal-effect-of-drugs": {
         "condition_name": "Extrapyramidal effect of drugs",
         "condition_slug": "extrapyramidal-effect-of-drugs",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Extrapyramidal effect of drugs is encountered rarely on Symcat. We will add more content to this page if enough people like you show interest.",
+        "condition_remarks": "Within all the people who go to their doctor with extrapyramidal effect of drugs, 66% report having abnormal involuntary movements, 41% report having seizures, and 31% report having anxiety and nervousness. The symptoms that are highly suggestive of extrapyramidal effect of drugs are abnormal involuntary movements, disturbance of memory, cramps and spasms, restlessness, neck stiffness or tightness, and arm stiffness or tightness, although you may still have extrapyramidal effect of drugs without those symptoms.",
+        "symptoms": {
+            "abnormal-involuntary-movements": {
+                "slug": "abnormal-involuntary-movements",
+                "probability": 66
+            },
+            "seizures": {
+                "slug": "seizures",
+                "probability": 41
+            },
+            "anxiety-and-nervousness": {
+                "slug": "anxiety-and-nervousness",
+                "probability": 31
+            },
+            "disturbance-of-memory": {
+                "slug": "disturbance-of-memory",
+                "probability": 25
+            },
+            "nausea": {
+                "slug": "nausea",
+                "probability": 25
+            },
+            "cramps-and-spasms": {
+                "slug": "cramps-and-spasms",
+                "probability": 25
+            },
+            "problems-with-movement": {
+                "slug": "problems-with-movement",
+                "probability": 25
+            },
+            "headache": {
+                "slug": "headache",
+                "probability": 25
+            },
+            "delusions-or-hallucinations": {
+                "slug": "delusions-or-hallucinations",
+                "probability": 18
+            },
+            "restlessness": {
+                "slug": "restlessness",
+                "probability": 18
+            },
+            "neck-stiffness-or-tightness": {
+                "slug": "neck-stiffness-or-tightness",
+                "probability": 18
+            },
+            "arm-stiffness-or-tightness": {
+                "slug": "arm-stiffness-or-tightness",
+                "probability": 10
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -96517,9 +103670,58 @@
     "eye-alignment-disorder": {
         "condition_name": "Eye alignment disorder",
         "condition_slug": "eye-alignment-disorder",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "Some eye movement disorders are present at birth. Others develop over time and may be associated with other problems, such as injuries. Treatments include glasses, eye muscle exercises, and surgery. There is no treatment for some kinds of eye movement disorders, such as most kinds of nystagmus.",
+        "condition_remarks": "Within all the people who go to their doctor with eye alignment disorder, 41% report having eye deviation, 39% report having diminished vision, and 36% report having double vision. The symptoms that are highly suggestive of eye alignment disorder are eye deviation, double vision, cross-eyed, symptoms of eye, eye moves abnormally, and abnormal movement of eyelid, although you may still have eye alignment disorder without those symptoms.",
+        "symptoms": {
+            "eye-deviation": {
+                "slug": "eye-deviation",
+                "probability": 41
+            },
+            "diminished-vision": {
+                "slug": "diminished-vision",
+                "probability": 39
+            },
+            "double-vision": {
+                "slug": "double-vision",
+                "probability": 36
+            },
+            "cross-eyed": {
+                "slug": "cross-eyed",
+                "probability": 35
+            },
+            "symptoms-of-eye": {
+                "slug": "symptoms-of-eye",
+                "probability": 28
+            },
+            "pain-in-eye": {
+                "slug": "pain-in-eye",
+                "probability": 14
+            },
+            "eye-moves-abnormally": {
+                "slug": "eye-moves-abnormally",
+                "probability": 11
+            },
+            "abnormal-movement-of-eyelid": {
+                "slug": "abnormal-movement-of-eyelid",
+                "probability": 6
+            },
+            "foreign-body-sensation-in-eye": {
+                "slug": "foreign-body-sensation-in-eye",
+                "probability": 6
+            },
+            "lack-of-growth": {
+                "slug": "lack-of-growth",
+                "probability": 6
+            },
+            "irregular-appearing-scalp": {
+                "slug": "irregular-appearing-scalp",
+                "probability": 3
+            },
+            "swollen-lymph-nodes": {
+                "slug": "swollen-lymph-nodes",
+                "probability": 3
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",
@@ -96600,9 +103802,58 @@
     "factitious-disorder": {
         "condition_name": "Factitious disorder",
         "condition_slug": "factitious-disorder",
-        "condition_description": null,
-        "condition_remarks": null,
-        "symptoms": {},
+        "condition_description": "A factitious disorder is a condition in which a person acts as if they have an illness by deliberately producing, feigning, or exaggerating symptoms. Factitious disorder by proxy is a condition in which a person deliberately produces, feigns, or exaggerates symptoms in a person in their care. M\u00fcnchausen syndrome, a severe form of factitious disorder, was the first kind identified, and was for a period the umbrella term for all such disorders. People with this condition may produce symptoms by contaminating urine samples, taking hallucinogens, injecting themselves with bacteria to produce infections, and other similar behaviour. They might be motivated to perpetrate factitious disorders either as a patient or by proxy as a caregiver to gain any variety of benefits including attention, nurturance, sympathy, and leniency that are seen as not obtainable any other way. In contrast, somatoform disorders are characterised by multiple somatic complaints, albeit both are diagnoses of exclusion.",
+        "condition_remarks": "Within all the people who go to their doctor with factitious disorder, 81% report having disturbance of memory, 72% report having depressive or psychotic symptoms, and 54% report having lip swelling. The symptoms that are highly suggestive of factitious disorder are disturbance of memory, depressive or psychotic symptoms, paresthesia, lip swelling, itchy eyelid, wrist weakness, excessive growth, elbow cramps or spasms, elbow weakness, and nailbiting, although you may still have factitious disorder without those symptoms.",
+        "symptoms": {
+            "disturbance-of-memory": {
+                "slug": "disturbance-of-memory",
+                "probability": 81
+            },
+            "depressive-or-psychotic-symptoms": {
+                "slug": "depressive-or-psychotic-symptoms",
+                "probability": 72
+            },
+            "depression": {
+                "slug": "depression",
+                "probability": 54
+            },
+            "loss-of-sensation": {
+                "slug": "loss-of-sensation",
+                "probability": 54
+            },
+            "paresthesia": {
+                "slug": "paresthesia",
+                "probability": 54
+            },
+            "lip-swelling": {
+                "slug": "lip-swelling",
+                "probability": 54
+            },
+            "itchy-eyelid": {
+                "slug": "itchy-eyelid",
+                "probability": 5
+            },
+            "wrist-weakness": {
+                "slug": "wrist-weakness",
+                "probability": 5
+            },
+            "excessive-growth": {
+                "slug": "excessive-growth",
+                "probability": 5
+            },
+            "elbow-cramps-or-spasms": {
+                "slug": "elbow-cramps-or-spasms",
+                "probability": 5
+            },
+            "elbow-weakness": {
+                "slug": "elbow-weakness",
+                "probability": 5
+            },
+            "nailbiting": {
+                "slug": "nailbiting",
+                "probability": 5
+            }
+        },
         "age": {
             "age-1-years": {
                 "name": "< 1 years",


### PR DESCRIPTION
Some lines in the symcat csv condition file deviate slightly from the
typical observed format. This causes the symptoms for that condition not
to be parsed. So you end up with conditions which do not have any
symptoms

Now handling these deviations.

This was the primary root cause for the dropped conditions as observed in #1 